### PR TITLE
[CALCITE-7559] SqlParserUtil.parseTimeTzLiteral should reject unknown…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
@@ -371,16 +371,24 @@ public final class SqlParserUtil {
       final String timeZone = s.substring(lastSpace + 1);
       final String time = s.substring(0, lastSpace);
 
-      final TimeZone tz = TimeZone.getTimeZone(timeZone);
-      if (tz != null) {
+      try {
+        ZoneId zoneId = ZoneId.of(timeZone);
+        TimeZone tz = TimeZone.getTimeZone(zoneId);
         pt =
             DateTimeUtils.parsePrecisionDateTimeLiteral(time, Format.get().time, tz, -1);
+      } catch (DateTimeException e) {
+        String message = e.getMessage();
+        if (message == null) {
+          message = "Error parsing TIME ZONE";
+        }
+        throw SqlUtil.newContextException(pos,
+            RESOURCE.illegalLiteral("TIME WITH TIME ZONE", s, message));
       }
     }
     if (pt == null) {
       throw SqlUtil.newContextException(pos,
           RESOURCE.illegalLiteral("TIME WITH TIME ZONE", s,
-              RESOURCE.badFormat(DateTimeUtils.TIME_FORMAT_STRING).str()));
+              RESOURCE.badFormat(DateTimeUtils.TIME_FORMAT_STRING + " zone").str()));
     }
     final TimeWithTimeZoneString t = TimeWithTimeZoneString.fromCalendarFields(pt.getCalendar())
         .withFraction(pt.getFraction());

--- a/core/src/test/java/org/apache/calcite/sql/parser/SqlParserUtilTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/parser/SqlParserUtilTest.java
@@ -19,6 +19,7 @@ package org.apache.calcite.sql.parser;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.runtime.CalciteContextException;
 import org.apache.calcite.sql.SqlIntervalQualifier;
+import org.apache.calcite.sql.SqlTimeTzLiteral;
 import org.apache.calcite.sql.SqlTimestampTzLiteral;
 
 import org.junit.jupiter.api.Test;
@@ -91,6 +92,36 @@ public class SqlParserUtilTest {
           ex.getMessage(), is("At line 2, column 3: Illegal TIMESTAMP WITH TIME ZONE literal "
               + "'2020-06-21 14:23:44.123654 incorrect_zone': Unknown "
               + "time-zone ID: incorrect_zone"));
+    }
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7559">[CALCITE-7559]
+   * SqlParserUtil.parseTimeTzLiteral should reject unknown time zones</a>. */
+  @Test void testTimeWithTimeZone() {
+    SqlParserPos pos = new SqlParserPos(2, 3);
+    SqlTimeTzLiteral lit =
+        SqlParserUtil.parseTimeTzLiteral("10:10:10 GMT", pos);
+    assertThat(lit, hasToString("TIME WITH TIME ZONE '10:10:10 UTC'"));
+
+    // Like parseTimestampTzLiteral, parseTimeTzLiteral should reject unknown
+    // time zones instead of silently falling back to GMT.
+    try {
+      SqlParserUtil.parseTimeTzLiteral("10:10:10 incorrect_zone", pos);
+      fail("Should be unreachable");
+    } catch (CalciteContextException ex) {
+      assertThat(
+          ex.getMessage(), is("At line 2, column 3: Illegal TIME WITH TIME ZONE literal "
+              + "'10:10:10 incorrect_zone': Unknown time-zone ID: incorrect_zone"));
+    }
+
+    try {
+      SqlParserUtil.parseTimeTzLiteral("10:10:10", pos);
+      fail("Should be unreachable");
+    } catch (CalciteContextException ex) {
+      assertThat(
+          ex.getMessage(), is("At line 2, column 3: Illegal TIME WITH TIME ZONE literal "
+              + "'10:10:10': not in format 'HH:mm:ss zone'"));
     }
   }
 


### PR DESCRIPTION
`SqlParserUtil.parseTimeTzLiteral(...)` used `TimeZone.getTimeZone(String)`, which silently falls back to GMT for unknown zone IDs, so invalid `TIME WITH TIME ZONE` literals were accepted instead of rejected. The sibling `parseTimestampTzLiteral(...)` already validates the zone via `ZoneId.of(...)`.

This applies the same pattern as CALCITE-7527: validate the zone with `ZoneId.of(...)` and throw a `CalciteContextException` on an invalid zone, making the two paths consistent.

Added `SqlParserUtilTest.testTimeWithTimeZone` covering a valid zone, an unknown zone, and a missing zone.
