### PR TITLE
[CALCITE-7578] `LIKE` with empty `ESCAPE` might fail with `StringIndexOutOfBoundsException`

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -529,11 +529,14 @@ public class RexSimplify {
       }
       if (e.operands.size() == 3 && e.operands.get(2) instanceof RexLiteral) {
         final RexLiteral escapeLiteral = (RexLiteral) e.operands.get(2);
-        Character escape = requireNonNull(escapeLiteral.getValueAs(Character.class));
-        e = (RexCall) rexBuilder
-            .makeCall(e.getParserPosition(), e.getOperator(), e.operands.get(0),
-                rexBuilder.makeLiteral(simplifyLikeString(likeStr, escape, '%'),
-                e.operands.get(1).getType(), true, true), escapeLiteral);
+        final String escapeStr = requireNonNull(escapeLiteral.getValueAs(String.class));
+        if (escapeStr.length() == 1) {
+          char escape = escapeStr.charAt(0);
+          e = (RexCall) rexBuilder
+              .makeCall(e.getParserPosition(), e.getOperator(), e.operands.get(0),
+                  rexBuilder.makeLiteral(simplifyLikeString(likeStr, escape, '%'),
+                      e.operands.get(1).getType(), true, true), escapeLiteral);
+        }
       }
     }
     return simplifyGenericNode(e);

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -4358,6 +4358,8 @@ class RexProgramTest extends RexProgramTestBase {
    * Multiple consecutive '%' in the string matched by LIKE should simplify to a single '%'</a>,
    * <a href="https://issues.apache.org/jira/browse/CALCITE-7153">[CALCITE-7153]
    * Mixed wildcards of _ and % need to be simplified in LIKE operator</a>.
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7578">[CALCITE-7578]
+   * LIKE with empty ESCAPE might fail with StringIndexOutOfBoundsException</a>.
    * */
   @Test void testSimplifyLike() {
     final RexNode ref = input(tVarchar(true, 10), 0);
@@ -4451,6 +4453,14 @@ class RexProgramTest extends RexProgramTestBase {
     // NOT(SIMILAR TO) is not optimized
     checkSimplifyUnchanged(
         not(rexBuilder.makeCall(SqlStdOperatorTable.SIMILAR_TO, ref, literal("%"))));
+
+    try {
+      // Empty ESCAPE
+      checkSimplifyUnchanged(like(ref, literal("a"), literal("")));
+    } catch (RuntimeException e) {
+      assertThat(e.getMessage(),
+          containsString("Invalid escape character ''"));
+    }
   }
 
   @Test void testSimplifyNullCheckInFilter() {


### PR DESCRIPTION
## Jira Link

[CALCITE-7578](https://issues.apache.org/jira/browse/CALCITE-7578)

## Changes Proposed
The PR improves `RexSimplify` for the case of `LIKE` with empty `ESCAPE` to make it not failing with `StringIndexOutOfBoundsException`