### PR TITLE
[CALCITE-7579] REGR_COUNT arguments are dropped in RelNode

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateReduceFunctionsRule.java
@@ -968,7 +968,8 @@ public class AggregateReduceFunctionsRule
             .addAll(SqlKind.AVG_AGG_FUNCTIONS)
             .addAll(SqlKind.COVAR_AVG_AGG_FUNCTIONS)
             .add(SqlKind.SUM)
-            .build();
+            .build().stream().filter(k -> k != SqlKind.REGR_COUNT)
+            .collect(ImmutableSet.toImmutableSet());
 
     @Override default AggregateReduceFunctionsRule toRule() {
       return new AggregateReduceFunctionsRule(this);

--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -39,7 +39,6 @@ import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlTimeLiteral;
 import org.apache.calcite.sql.SqlTimestampLiteral;
 import org.apache.calcite.sql.SqlUtil;
-import org.apache.calcite.sql.fun.SqlCountAggFunction;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
@@ -388,7 +387,7 @@ public class RexBuilder {
       List<AggregateCall> aggCalls,
       Map<AggregateCall, RexNode> aggCallMapping,
       IntPredicate isNullable) {
-    if (aggCall.getAggregation() instanceof SqlCountAggFunction
+    if (aggCall.getAggregation().getKind() == SqlKind.COUNT
         && !aggCall.isDistinct()) {
       final List<Integer> args = aggCall.getArgList();
       final List<Integer> nullableArgs = nullableArgs(args, isNullable);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCountAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCountAggFunction.java
@@ -55,9 +55,14 @@ public class SqlCountAggFunction extends SqlAggFunction {
 
   public SqlCountAggFunction(String name,
       SqlOperandTypeChecker sqlOperandTypeChecker) {
-    super(name, null, SqlKind.COUNT, ReturnTypes.BIGINT, null,
-        sqlOperandTypeChecker, SqlFunctionCategory.NUMERIC, false, false,
-        Optionality.FORBIDDEN);
+    this(name, sqlOperandTypeChecker, SqlKind.COUNT);
+  }
+
+  public SqlCountAggFunction(String name,
+      SqlOperandTypeChecker sqlOperandTypeChecker,
+      SqlKind sqlKind) {
+    super(name, null, sqlKind, ReturnTypes.BIGINT, null, sqlOperandTypeChecker,
+        SqlFunctionCategory.NUMERIC, false, false, Optionality.FORBIDDEN);
   }
 
   //~ Methods ----------------------------------------------------------------

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlRegrCountAggFunction.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlRegrCountAggFunction.java
@@ -29,7 +29,7 @@ import static com.google.common.base.Preconditions.checkArgument;
  */
 public class SqlRegrCountAggFunction extends SqlCountAggFunction {
   public SqlRegrCountAggFunction(SqlKind kind) {
-    super("REGR_COUNT", OperandTypes.NUMERIC_NUMERIC);
+    super("REGR_COUNT", OperandTypes.NUMERIC_NUMERIC, kind);
     checkArgument(SqlKind.REGR_COUNT == kind, "unsupported sql kind: " + kind);
   }
 }


### PR DESCRIPTION
REGR_COUNT(y, x) was incorrectly converted to REGR_COUNT(*) because SqlRegrCountAggFunction extends SqlCountAggFunction, which:

1. Hardcodes SqlKind.COUNT in its constructor, causing REGR_COUNT to report the wrong SqlKind.
2. Causes RexBuilder.addAggCall() to match REGR_COUNT via SqlKind.COUNT and strip non-nullable arguments (an optimization valid only for COUNT).
3. Masked a missing case handler in AggregateReduceFunctionsRule, since SqlKind.COUNT is not in functionsToReduce.

Fix:
- Add a protected constructor to SqlCountAggFunction that accepts SqlKind, allowing subclasses to specify their own kind.
- Update SqlRegrCountAggFunction to pass SqlKind.REGR_COUNT.
- Guard the nullable-args optimization in RexBuilder.addAggCall() to check SqlKind == COUNT instead of instanceof.
- Add case REGR_COUNT in AggregateReduceFunctionsRule to preserve it as-is, since it is irreducible.

<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

https://issues.apache.org/jira/browse/CALCITE-7579

## Problem
When parses `REGR_COUNT(y, x)` the SqlKind is mistakenly set to `SqlKind.COUNT` instead of `SqlKind.REGR_COUNT`, the agg builder then drop the args `y` and `x` and replace with `*`, leading to empty arg list of the agg call at RelNode stage.
A way to repro it is, parse and plan it, then convert it back to SQL, it would be:
```
REGR_COUNT(y, x) -> REGR_COUNT(*)
```
which is semantically incorrect


## Changes Proposed
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.
-->

- Correct the SqlKind to REGR_COUNT
- At build agg call, check SqlKind instead of `instanceof` thus it always focuses on real count and bypass regr_count
- Remove regr_count from `AggregateReduceFunctionsRule` given it is irreducible.
