### PR TITLE
[CALCITE-7560] SqlFunctions.DateParseFunction.parseTimestamp(..., timeZone) accepts unknown time zones and silently falls back to GMT

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -5604,7 +5604,9 @@ public class SqlFunctions {
 
     public long parseTimestamp(String fmtString, String timestamp,
         String timeZone) {
-      TimeZone tz = TimeZone.getTimeZone(timeZone);
+      // Validate the zone id (rejecting unknown ids) rather than letting
+      // TimeZone.getTimeZone silently fall back to GMT.
+      TimeZone tz = TimeZone.getTimeZone(ZoneId.of(timeZone));
       final long millisSinceEpoch =
           internalParseDatetime(fmtString, timestamp, timeZone);
       return toLong(new java.sql.Timestamp(millisSinceEpoch), tz);

--- a/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlFunctionsTest.java
@@ -90,6 +90,7 @@ import static org.hamcrest.Matchers.hasToString;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -2092,5 +2093,23 @@ class SqlFunctionsTest {
     assertThat(result, hasSize(2));
     assertArrayEquals(new Object[]{null, 100}, result.get(0));
     assertArrayEquals(new Object[]{null, 200}, result.get(1));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7560">[CALCITE-7560]
+   * SqlFunctions.DateParseFunction.parseTimestamp(..., timeZone) accepts unknown
+   * time zones and silently falls back to GMT</a>. */
+  @Test void testParseTimestampRejectsUnknownTimeZone() {
+    final SqlFunctions.DateParseFunction parse = new SqlFunctions.DateParseFunction();
+
+    // A valid time zone is accepted.
+    assertThat(
+        parse.parseTimestamp("%Y-%m-%d %H:%M:%S", "2024-01-01 00:00:00", "UTC"),
+        is(parse.parseTimestamp("%Y-%m-%d %H:%M:%S", "2024-01-01 00:00:00")));
+
+    // An unknown time zone is rejected rather than silently reinterpreted as GMT.
+    assertThrows(RuntimeException.class,
+        () -> parse.parseTimestamp("%Y-%m-%d %H:%M:%S",
+            "2024-01-01 00:00:00", "Asia/Sanghai"));
   }
 }


### PR DESCRIPTION
`SqlFunctions.DateParseFunction.parseTimestamp(fmt, string, timeZone)` used
`TimeZone.getTimeZone(String)`, which silently falls back to GMT for unknown zone
IDs, so a typo in the time-zone argument of BigQuery-style `PARSE_TIMESTAMP` changed
query results instead of raising an error.

Following the same approach as CALCITE-7559, the zone is now validated with
`ZoneId.of(...)`, which throws for unknown ids. The check runs before the cached
`DateFormat` path, so that path no longer sees an unvalidated zone either.

Added `SqlFunctionsTest.testParseTimestampRejectsUnknownTimeZone`.