### PR TITLE
[CALCITE-7588] `LIKE` with `ESCAPE` symbols containing wildcards fails

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -546,7 +546,7 @@ public class RexSimplify {
   // string with even escapes 'AA\\\\%%__%%AA' simplify to 'AA\\__%AA'
   // string with odd escapes 'AA\\\\\\%%__%%AA' simplify to 'AA\\\\\\%__%AA'
   private String simplifyMixedWildcards(String str, char escape) {
-    Pattern pattern = Pattern.compile("[_%]+");
+    Pattern pattern = getWildCardPattern(escape);
     Matcher matcher = pattern.matcher(str);
     StringBuilder builder = new StringBuilder();
     int from = 0;
@@ -568,6 +568,17 @@ public class RexSimplify {
       builder.append(str.substring(from));
     }
     return builder.toString();
+  }
+
+  private static Pattern getWildCardPattern(char escape) {
+    switch (escape) {
+    case '%':
+      return Pattern.compile("_+");
+    case '_':
+      return Pattern.compile("%+");
+    default:
+      return Pattern.compile("[_%]+");
+    }
   }
 
   // Tool method: count the number of consecutive identical characters before index

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -4360,6 +4360,8 @@ class RexProgramTest extends RexProgramTestBase {
    * Mixed wildcards of _ and % need to be simplified in LIKE operator</a>.
    * <a href="https://issues.apache.org/jira/browse/CALCITE-7578">[CALCITE-7578]
    * LIKE with empty ESCAPE might fail with StringIndexOutOfBoundsException</a>.
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7588">[CALCITE-7588]
+   * LIKE with ESCAPE symbols containing wildcards fails</a>.
    * */
   @Test void testSimplifyLike() {
     final RexNode ref = input(tVarchar(true, 10), 0);
@@ -4423,6 +4425,14 @@ class RexProgramTest extends RexProgramTestBase {
         "LIKE($0, '###%%#%#%A#%%#%A%###%%', '#')");
     checkSimplifyUnchanged(like(ref, literal("A"), literal("#")));
     checkSimplifyUnchanged(like(ref, literal("%A"), literal("#")));
+    checkSimplifyUnchanged(like(ref, literal("TE%_ST"), literal("%")));
+    checkSimplifyUnchanged(like(ref, literal("TE%%ST"), literal("%")));
+    checkSimplifyUnchanged(like(ref, literal("a%_b%%c"), literal("%")));
+    checkSimplifyUnchanged(like(ref, literal("%_%%A%_"), literal("%")));
+    // escape char equal to the '_' wildcard. '%E__S%' ESCAPE '_' is a literal '_'.
+    checkSimplifyUnchanged(like(ref, literal("%E__S%"), literal("_")));
+    checkSimplifyUnchanged(like(ref, literal("TE_%ST"), literal("_")));
+    checkSimplifyUnchanged(like(ref, literal("a_%b__c"), literal("_")));
 
     // As above, but ref is NOT NULL
     final RexNode refMandatory = vVarcharNotNull(0);


### PR DESCRIPTION

## Jira Link

[CALCITE-7588](https://issues.apache.org/jira/browse/CALCITE-7588)

## Changes Proposed
The PR fixes the behavior of `LIKE` with `ESCAPE` containing wildcard symbols