### PR TITLE
[CALCITE-7589] `JOIN ... USING` might fail with disabled type coercion

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -3642,9 +3642,10 @@ public class SqlToRelConverter {
         offset += rowType.getFieldList().size();
       }
 
-      RelDataType resultType =
-          validator().getTypeCoercion().commonTypeForBinaryComparison(
-              comparedTypes.get(0), comparedTypes.get(1));
+      RelDataType resultType = validator().config().typeCoercionEnabled()
+          ? validator().getTypeCoercion().commonTypeForBinaryComparison(
+              comparedTypes.get(0), comparedTypes.get(1))
+          : null;
       if (resultType == null) {
         // Leave call unchanged (as it happens in TypeCoercionImpl#binaryComparisonCoercion)
         list.add(rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, operands));

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -5397,6 +5397,13 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
         .ok();
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7589">[CALCITE-7589]
+   * JOIN ... USING might fail with disabled type coercion</a>. */
+  @Test void testNaturalJoinCastNoCoercion2() {
+    final String sql = "select * from emp join dept using(deptno)";
+    sql(sql).withTypeCoercion(false).ok();
+  }
+
   /** Tests LEFT JOIN LATERAL with multiple columns from outer. */
   @Test void testLeftJoinLateral4() {
     final String sql = "select * from (values (4,5)) as t(c,d)\n"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -5696,6 +5696,19 @@ LogicalProject(X=[CAST($0):DECIMAL(2, 1) NOT NULL])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testNaturalJoinCastNoCoercion2">
+    <Resource name="sql">
+      <![CDATA[select * from emp join dept using(deptno)]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(DEPTNO=[$7], EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], SLACKER=[$8], NAME=[$10])
+  LogicalJoin(condition=[=($7, $9)], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNestedAggregates">
     <Resource name="sql">
       <![CDATA[SELECT


### PR DESCRIPTION
## Jira Link

[CALCITE-7589](https://issues.apache.org/jira/browse/CALCITE-7589)

## Changes Proposed
The PR fixes `JOIN ... USING` for the case of disabled coercion