### PR TITLE
[CALCITE-4353] Validator fails to expand order expression with dot operator

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -7894,7 +7894,11 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
       if (call instanceof SqlSelect) {
         return call;
       }
-      return super.visitScoped(call);
+      // Only visit expression arguments. For DOT calls (e.g. 'employees[1].detail'),
+      // operand[1] is a field name, not a column reference, and must not be qualified.
+      CallCopyingArgHandler argHandler = new CallCopyingArgHandler(call, false);
+      call.getOperator().acceptCall(this, call, true, argHandler);
+      return argHandler.result();
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -9841,6 +9841,9 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("SELECT dept_nested.employees[1].detail.skills[1].others.a as oa\n"
         + "from dept_nested")
         .type("RecordType(VARCHAR(10) OA) NOT NULL");
+    // Test case for [CALCITE-4353] Validator fails to expand order expression with dot operator
+    sql("select * from dept_nested order by employees[1].detail.skills[2+3].desc")
+        .ok();
   }
 
   @Test void testItemOperatorException() {

--- a/core/src/test/resources/sql/sort.iq
+++ b/core/src/test/resources/sql/sort.iq
@@ -533,4 +533,20 @@ SELECT * FROM emp ORDER BY deptno, null, empno;
 
 !ok
 
+# [CALCITE-4353] Validator fails to expand order expression with dot operator
+!use bookstore
+select au."name" as author, au."books"[1]."title" title
+from "bookstore"."authors" au
+order by au."books"[1]."title";
++-------------------+-----------------+
+| AUTHOR            | TITLE           |
++-------------------+-----------------+
+| Victor Hugo       | Les Misérables  |
+| Nikos Kazantzakis | Zorba the Greek |
+| Homer             |                 |
++-------------------+-----------------+
+(3 rows)
+
+!ok
+
 # End sort.iq


### PR DESCRIPTION
## Jira Link

[CALCITE-4353](https://issues.apache.org/jira/browse/CALCITE-4353)
