### PR TITLE
[CALCITE-7601] Harden ST_GeomFromGML against external entity expansion

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
@@ -143,8 +143,11 @@ public class SpatialTypeUtils {
       // GMLReader.read builds its own SAXParserFactory with DOCTYPE enabled, so
       // parse with a hardened reader and feed JTS's GMLHandler. Disallowing the
       // DOCTYPE declaration rejects any external subset or entities outright.
+      // JTS's GMLReader parses without namespace awareness, and GML values here
+      // use the gml: prefix without declaring it, so keep the parser
+      // non-namespace-aware to match.
       final SAXParserFactory factory = SAXParserFactory.newInstance();
-      factory.setNamespaceAware(true);
+      factory.setNamespaceAware(false);
       factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
       final SAXParser parser = factory.newSAXParser();
       final XMLReader xmlReader = parser.getXMLReader();

--- a/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
@@ -151,6 +151,9 @@ public class SpatialTypeUtils {
       factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
       final SAXParser parser = factory.newSAXParser();
       final XMLReader xmlReader = parser.getXMLReader();
+      // GMLReader itself passes a null delegate ErrorHandler; the parameter is
+      // not annotated, so suppress the nullness warning it would otherwise emit.
+      @SuppressWarnings("argument.type.incompatible")
       final GMLHandler handler = new GMLHandler(GEOMETRY_FACTORY, null);
       xmlReader.setContentHandler(handler);
       xmlReader.parse(new InputSource(new StringReader(gml)));

--- a/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
@@ -140,13 +140,12 @@ public class SpatialTypeUtils {
    */
   public static Geometry fromGml(String gml) {
     try {
-      // GMLReader.read builds its own SAXParserFactory with external entities
-      // enabled, so parse with a hardened reader and feed JTS's GMLHandler.
+      // GMLReader.read builds its own SAXParserFactory with DOCTYPE enabled, so
+      // parse with a hardened reader and feed JTS's GMLHandler. Disallowing the
+      // DOCTYPE declaration rejects any external subset or entities outright.
       final SAXParserFactory factory = SAXParserFactory.newInstance();
       factory.setNamespaceAware(true);
       factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
       final SAXParser parser = factory.newSAXParser();
       final XMLReader xmlReader = parser.getXMLReader();
       final GMLHandler handler = new GMLHandler(GEOMETRY_FACTORY, null);

--- a/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
@@ -31,14 +31,19 @@ import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.io.WKTWriter;
 import org.locationtech.jts.io.geojson.GeoJsonReader;
 import org.locationtech.jts.io.geojson.GeoJsonWriter;
-import org.locationtech.jts.io.gml2.GMLReader;
+import org.locationtech.jts.io.gml2.GMLHandler;
 import org.locationtech.jts.io.gml2.GMLWriter;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.Locale;
 import java.util.regex.Pattern;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 
 import static java.lang.Integer.parseInt;
 
@@ -135,8 +140,19 @@ public class SpatialTypeUtils {
    */
   public static Geometry fromGml(String gml) {
     try {
-      GMLReader reader = new GMLReader();
-      return reader.read(gml, GEOMETRY_FACTORY);
+      // GMLReader.read builds its own SAXParserFactory with external entities
+      // enabled, so parse with a hardened reader and feed JTS's GMLHandler.
+      final SAXParserFactory factory = SAXParserFactory.newInstance();
+      factory.setNamespaceAware(true);
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+      final SAXParser parser = factory.newSAXParser();
+      final XMLReader xmlReader = parser.getXMLReader();
+      final GMLHandler handler = new GMLHandler(GEOMETRY_FACTORY, null);
+      xmlReader.setContentHandler(handler);
+      xmlReader.parse(new InputSource(new StringReader(gml)));
+      return handler.getGeometry();
     } catch (SAXException | IOException | ParserConfigurationException e) {
       throw new RuntimeException("Unable to parse GML");
     }

--- a/core/src/test/java/org/apache/calcite/runtime/SpatialTypeUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/runtime/SpatialTypeUtilsTest.java
@@ -53,8 +53,8 @@ class SpatialTypeUtilsTest {
   }
 
   @Test void testFromGml() {
-    Geometry g = SpatialTypeUtils.fromGml(
-        "<gml:Point xmlns:gml=\"http://www.opengis.net/gml\">"
+    Geometry g =
+        SpatialTypeUtils.fromGml("<gml:Point xmlns:gml=\"http://www.opengis.net/gml\">"
         + "<gml:coordinates>1,2</gml:coordinates></gml:Point>");
     assertThat(g.getCoordinate().getX(), is(1D));
     assertThat(g.getCoordinate().getY(), is(2D));

--- a/core/src/test/java/org/apache/calcite/runtime/SpatialTypeUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/runtime/SpatialTypeUtilsTest.java
@@ -21,8 +21,13 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link org.apache.calcite.runtime.SpatialTypeUtilsTest}.
@@ -45,6 +50,32 @@ class SpatialTypeUtilsTest {
         + "  POINT(5 6),\n"
         + "  LINESTRING(1 1, 1 6))");
     assertThat(g3.getSRID(), is(0));
+  }
+
+  @Test void testFromGml() {
+    Geometry g = SpatialTypeUtils.fromGml(
+        "<gml:Point xmlns:gml=\"http://www.opengis.net/gml\">"
+        + "<gml:coordinates>1,2</gml:coordinates></gml:Point>");
+    assertThat(g.getCoordinate().getX(), is(1D));
+    assertThat(g.getCoordinate().getY(), is(2D));
+  }
+
+  /** A GML document declaring an external entity must be rejected, not have the
+   * entity resolved and its target file inlined into the geometry. The secret
+   * file holds a valid coordinate so an unguarded parser would parse it and
+   * succeed; the doctype guard makes parsing fail instead. */
+  @Test void testFromGmlRejectsExternalEntities() throws Exception {
+    Path secret = Files.createTempFile("calcite-gml-xxe", ".txt");
+    try {
+      Files.write(secret, "7".getBytes(StandardCharsets.UTF_8));
+      String gml = "<?xml version=\"1.0\"?>"
+          + "<!DOCTYPE gml [ <!ENTITY xxe SYSTEM \"" + secret.toUri() + "\"> ]>"
+          + "<gml:Point xmlns:gml=\"http://www.opengis.net/gml\">"
+          + "<gml:coordinates>&xxe;,8</gml:coordinates></gml:Point>";
+      assertThrows(RuntimeException.class, () -> SpatialTypeUtils.fromGml(gml));
+    } finally {
+      Files.deleteIfExists(secret);
+    }
   }
 
   @Test void testAsEwkt() {


### PR DESCRIPTION
## Jira Link

A Jira can be filed for this if preferred; raising the patch first since the change is small and self-contained.

## Changes Proposed

`Repro:` `SELECT ST_GeomFromGML(g)` where `g` is a GML string carrying a DOCTYPE with an external entity, e.g. `<!DOCTYPE x [ <!ENTITY e SYSTEM "file:///etc/passwd"> ]>` referenced from `<gml:coordinates>&e;,0</gml:coordinates>`.

`Expected:` the entity is not resolved.

`Actual:` `fromGml` builds a JTS `GMLReader`, whose internal `SAXParserFactory` leaves DOCTYPE and external general/parameter entities enabled, so the parser fetches the entity target and inlines it into the geometry. That is local file read / SSRF (XXE) from row data, since the GML argument crosses the trust boundary at the `ST_GeomFromGML` SQL function.

`Fix:` parse with a `SAXParser` configured with `disallow-doctype-decl` and external entities off, feeding JTS's own `GMLHandler`. Same hardening already used in `XmlFunctions` and `DiffRepository`.

`Test:` `SpatialTypeUtilsTest` gets a regression that points an external entity at a temp file holding a valid coordinate, so an unguarded parser would return `POINT (7 8)` while the guarded one rejects the document.
