### PR TITLE
[CALCITE-7600] Quote PARSE_URL key before building the query regex

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -1859,7 +1859,7 @@ public class SqlFunctions {
   @Deterministic
   public static class ParseUrlFunction {
     static Pattern keyToPattern(String keyToExtract) {
-      return Pattern.compile("(&|^)" + keyToExtract + "=([^&]*)");
+      return Pattern.compile("(&|^)" + Pattern.quote(keyToExtract) + "=([^&]*)");
     }
 
     private final LoadingCache<String, Pattern> cache =

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -5204,6 +5204,16 @@ public class SqlOperatorTest {
           "VARCHAR");
       f.checkNull("parse_url('http://calcite.apache.org/path1/p.php?k1=v1&k2=v2#Ref1',"
           + " 'QUERY', 'k3')");
+      // key is matched literally, regex metacharacters do not match other keys
+      f.checkNull("parse_url('http://calcite.apache.org/path1/p.php?k1=v1&k2=v2#Ref1',"
+          + " 'QUERY', 'k.')");
+      f.checkString("parse_url('http://calcite.apache.org/path1/p.php?a.b=v1&axb=v2#Ref1',"
+              + " 'QUERY', 'a.b')",
+          "v1",
+          "VARCHAR");
+      // a key that is not a valid regex must not raise an error
+      f.checkNull("parse_url('http://calcite.apache.org/path1/p.php?k1=v1&k2=v2#Ref1',"
+          + " 'QUERY', '(')");
       f.checkString("parse_url('http://calcite.apache.org/path1/p.php?k1=v1&k2=v2#Ref1',"
               + " 'FILE')",
           "/path1/p.php?k1=v1&k2=v2",


### PR DESCRIPTION
## Jira Link

A Jira can be filed for this if preferred; raising the patch first since the change is a small, self-contained fix.

## Changes Proposed

`Repro:` `parse_url('http://h/p?k1=v1&k2=v2', 'QUERY', 'k.')` and `parse_url('http://h/p?k1=v1', 'QUERY', '(')`.

`Expected:` the first returns `NULL` (no parameter is literally named `k.`); the second returns `NULL` (no parameter named `(`).

`Actual:` `ParseUrlFunction.keyToPattern` builds the lookup with `Pattern.compile("(&|^)" + keyToExtract + "=([^&]*)")`, so the key is spliced into the regex unescaped. The key is the third `PARSE_URL` argument and crosses the trust boundary. Regex metacharacters in the key are interpreted, so `k.` matches `k1` and wrongly returns `v1`, and a key that is not a valid regex such as `(` throws `PatternSyntaxException` out of the function instead of yielding a result.

`Fix:` wrap the key in `Pattern.quote` so it is matched literally, which is the documented key semantics. `Pattern.quote` is already the idiom used elsewhere in `SqlFunctions` (the `split` helper).

`Test:` `SqlOperatorTest.testParseUrl` gains cases for a metacharacter key and a non-regex key; both fail on the unpatched tree and pass after.
