### PR TITLE
[CALCITE-7598] Query with HAVING empno BETWEEN NULL AND NULL crashes the compiler

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -3819,7 +3819,8 @@ public class SqlToRelConverter {
       if (having != null) {
         SqlNode newHaving = pushDownNotForIn(bb.scope, having);
         replaceSubQueries(bb, newHaving, RelOptUtil.Logic.UNKNOWN_AS_FALSE);
-        havingExpr = bb.convertExpression(newHaving);
+        RexNode having0 = bb.convertExpression(newHaving);
+        havingExpr = simplifyPredicate(having0);
       } else {
         havingExpr = relBuilder.literal(true);
       }

--- a/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelMetadataTest.java
@@ -4531,6 +4531,16 @@ public class RelMetadataTest {
     SqlValidatorTester.DEFAULT.convertSqlToRel(factory, sql, false, false);
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7598">[CALCITE-7598]
+   * Query with HAVING empno BETWEEN NULL AND NULL crashes the compiler</a>. */
+  @Test void testHavingCrash() {
+    String sql = "SELECT DISTINCT empno FROM emp GROUP BY empno HAVING empno BETWEEN NULL AND NULL";
+    SqlTestFactory factory = SqlTestFactory.INSTANCE
+        .withSqlToRelConfig(
+            c -> c.withRelBuilderConfigTransform(t -> t.withSimplify(false)));
+    SqlValidatorTester.DEFAULT.convertSqlToRel(factory, sql, false, false);
+  }
+
   @Test void testAllPredicates() {
     final Project rel = (Project) sql("select * from emp, dept").toRel();
     final Join join = (Join) rel.getInput();


### PR DESCRIPTION
## Jira Link

[CALCITE-7598]https://issues.apache.org/jira/browse/CALCITE-7598)

This is very similar to https://github.com/apache/calcite/pull/4586