### PR TITLE
[CALCITE-7599] Enhance parser to allow numeric literals as values in k/v hints as suggested by documentation

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1277,6 +1277,8 @@ void AddKeyValueOption(List<SqlNode> list) :
     )
     <EQ>
     (
+        value = NumericLiteral()
+    |
         value = StringLiteral()
     |
         value = SimpleIdentifier()

--- a/core/src/main/java/org/apache/calcite/sql/SqlHint.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlHint.java
@@ -197,18 +197,19 @@ public class SqlHint extends SqlCall {
      * The hint options are list of key-value pairs.
      * For each pair,
      * the key is a simple identifier or string literal,
-     * the value is a string literal.
+     * the value is a string or numeric literal.
      */
     KV_LIST
   }
 
   //~ Tools ------------------------------------------------------------------
 
-  private static String getOptionAsString(SqlNode node) {
+  private String getOptionAsString(SqlNode node) {
     assert node instanceof SqlIdentifier || SqlUtil.isLiteral(node);
     if (node instanceof SqlIdentifier) {
       return ((SqlIdentifier) node).getSimple();
     }
-    return ((SqlLiteral) node).getValueAs(String.class);
+    return requireNonNull(((SqlLiteral) node).toValue(),
+        () -> "null hint literal in " + options);
   }
 }

--- a/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlHintsConverterTest.java
@@ -172,7 +172,7 @@ class SqlHintsConverterTest {
   /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7498">[CALCITE-7498]
    * The parser rejects the example hints from the documentation</a>. */
   @Test void testDocumentationExample() {
-    final String sql = "SELECT /*+ hint1, hint2(a='1', b='2') */ *\n"
+    final String sql = "SELECT /*+ hint1, hint2(a=1, b=2) */ *\n"
         + "FROM emp /*+ hint3(5, 'x') */\n"
         + "JOIN dept /*+ hint4(c=id), hint5 */\n"
         + "ON emp.deptno = dept.deptno";
@@ -197,6 +197,12 @@ class SqlHintsConverterTest {
 
   @Test void testQueryHintWithLiteralOptions() {
     final String sql = "select /*+ time_zone(1, 1.23, 'a bc', -1.0) */ *\n"
+        + "from emp";
+    sql(sql).ok();
+  }
+
+  @Test void testQueryHintWithKeyValueNumericLiteralOptions() {
+    final String sql = "select /*+ hint2(a=1, b=-1, c=1.1, d=-1.1, e=1e3, f=-1e-4) */ *\n"
         + "from emp";
     sql(sql).ok();
   }

--- a/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlHintsConverterTest.xml
@@ -60,7 +60,7 @@ Correlate:[[USE_HASH_JOIN inheritPath:[0] options:[ORDERS, PRODUCTS_TEMPORAL]]]
   </TestCase>
   <TestCase name="testDocumentationExample">
     <Resource name="sql">
-      <![CDATA[SELECT /*+ hint1, hint2(a='1', b='2') */ *
+      <![CDATA[SELECT /*+ hint1, hint2(a=1, b=2) */ *
 FROM emp /*+ hint3(5, 'x') */
 JOIN dept /*+ hint4(c=id), hint5 */
 ON emp.deptno = dept.deptno]]>
@@ -350,6 +350,17 @@ LogicalJoin:[[NO_HASH_JOIN inheritPath:[0, 0]]]
 TableScan:[[PROPERTIES inheritPath:[0, 0, 0] options:{K1=v1, K2=v2}], [INDEX inheritPath:[0, 0, 0] options:[ENAME]]]
 TableScan:[[PROPERTIES inheritPath:[0, 0, 1] options:{K1=v1, K2=v2}], [INDEX inheritPath:[0, 0, 1] options:[ENAME]]]
 TableScan:[[PROPERTIES inheritPath:[0, 1, 0] options:{K1=v1, K2=v2}], [INDEX inheritPath:[0, 1, 0] options:[ENAME]]]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testQueryHintWithKeyValueNumericLiteralOptions">
+    <Resource name="sql">
+      <![CDATA[select /*+ hint2(a=1, b=-1, c=1.1, d=-1.1, e=1e3, f=-1e-4) */ *
+from emp]]>
+    </Resource>
+    <Resource name="hints">
+      <![CDATA[
+Project:[[HINT2 inheritPath:[] options:{A=1, B=-1, C=1.1, D=-1.1, E=1E3, F=-1E-4}]]
 ]]>
     </Resource>
   </TestCase>

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -3598,11 +3598,13 @@ optionKey:
 
 optionVal:
       simpleIdentifier
+  |   numericLiteral
   |   stringLiteral
 
 hintOption:
       simpleIdentifier
-   |  stringLiteral
+  |   numericLiteral
+  |   stringLiteral
 {% endhighlight %}
 
 It is experimental in Calcite, and yet not fully implemented, what we have implemented are:

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -9693,7 +9693,12 @@ public class SqlParserTest {
     final String sql1 = "select "
         + "/*+ properties(^k1^=123, k2='v2'), no_hash_join() */ "
         + "empno, ename, deptno from emps";
-    sql(sql1).fails("(?s).*Encountered \"k1 = 123\" at .*");
+    // Allow numeric literal k/v values.
+    final String expected1 = "SELECT\n"
+        + "/*+ `PROPERTIES`(`K1` = 123, `K2` = 'v2'), `NO_HASH_JOIN` */\n"
+        + "`EMPNO`, `ENAME`, `DEPTNO`\n"
+        + "FROM `EMPS`";
+    sql(sql1).ok(expected1);
     final String sql2 = "select "
         + "/*+ properties(k1, k2^=^'v2'), no_hash_join */ "
         + "empno, ename, deptno from emps";


### PR DESCRIPTION
[CALCITE-7599](https://issues.apache.org/jira/browse/CALCITE-7599)

This is a small refinement to CALCITE-7498 to finish alignment of the reference documentation example, the reference documentation grammar, and the actual parser grammar. The alignment here could have used a different fixed point, but I figured I would follow the original example and align on the example query as the source of truth. This also has the nice side-effect of supporting the largest set of valid hints.