### PR TITLE
[CALCITE-7556] NameMultimap.remove(key, value) leaves an empty key bucket behind

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/NameMultimap.java
+++ b/core/src/main/java/org/apache/calcite/util/NameMultimap.java
@@ -16,8 +16,6 @@
  */
 package org.apache.calcite.util;
 
-import org.apache.calcite.linq4j.function.Experimental;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.ArrayList;
@@ -71,13 +69,16 @@ public class NameMultimap<V> {
   /** Removes all entries that have the given case-sensitive key.
    *
    * @return Whether a value was removed */
-  @Experimental
   public boolean remove(String key, V value) {
     final List<V> list = map().get(key);
     if (list == null) {
       return false;
     }
-    return list.remove(value);
+    boolean result = list.remove(value);
+    if (list.isEmpty()) {
+      map().remove(key);
+    }
+    return result;
   }
 
   /** Returns a map containing all the entries in this multimap that match the

--- a/core/src/test/java/org/apache/calcite/util/UtilTest.java
+++ b/core/src/test/java/org/apache/calcite/util/UtilTest.java
@@ -3292,4 +3292,17 @@ class UtilTest {
     m.describeTo(d);
     return d.toString();
   }
+
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7556">[CALCITE-7556]
+   * NameMultimap.remove(key, value) leaves an empty key bucket behind</a>. */
+  @Test void testNameMultimapRemoveLastValueRemovesKey() {
+    final NameMultimap<Integer> map = new NameMultimap<>();
+    map.put("baz", 1);
+
+    assertTrue(map.remove("baz", 1));
+    assertThat(map.range("baz", true), hasSize(0));
+    assertThat(map.containsKey("baz", true), is(false));
+    assertThat(map.containsKey("BAZ", false), is(false));
+    assertThat(map.map(), aMapWithSize(0));
+  }
 }


### PR DESCRIPTION
## Jira Link

[CALCITE-7556](https://issues.apache.org/jira/browse/CALCITE-7556)

