### PR TITLE
[CALCITE-7585] SqlMerge unparse EXISTS predicates in ON clause without parentheses

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDelete.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDelete.java
@@ -152,7 +152,8 @@ public class SqlDelete extends SqlCall {
     }
     SqlNode condition = this.condition;
     if (condition != null) {
-      SqlUtil.unparseWhereClause(writer, condition, opLeft, opRight);
+      writer.sep("WHERE");
+      SqlUtil.unparseConditionClause(writer, condition, opLeft, opRight);
     }
     writer.endList(frame);
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlMerge.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlMerge.java
@@ -197,9 +197,8 @@ public class SqlMerge extends SqlCall {
     writer.keyword("USING");
     source.unparse(writer, opLeft, opRight);
 
-    writer.newlineAndIndent();
-    writer.keyword("ON");
-    condition.unparse(writer, opLeft, opRight);
+    writer.sep("ON");
+    SqlUtil.unparseConditionClause(writer, condition, opLeft, opRight);
 
     SqlUpdate updateCall = this.updateCall;
     if (updateCall != null) {

--- a/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSelectOperator.java
@@ -173,7 +173,8 @@ public class SqlSelectOperator extends SqlOperator {
 
     SqlNode where = select.where;
     if (where != null) {
-      SqlUtil.unparseWhereClause(writer, where, 0, 0);
+      writer.sep("WHERE");
+      SqlUtil.unparseConditionClause(writer, where, 0, 0);
     }
     if (select.groupBy != null) {
       SqlNodeList groupBy =

--- a/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUpdate.java
@@ -202,7 +202,8 @@ public class SqlUpdate extends SqlCall {
     writer.endList(setFrame);
     SqlNode condition = this.condition;
     if (condition != null) {
-      SqlUtil.unparseWhereClause(writer, condition, opLeft, opRight);
+      writer.sep("WHERE");
+      SqlUtil.unparseConditionClause(writer, condition, opLeft, opRight);
     }
     writer.endList(frame);
   }

--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -455,34 +455,30 @@ public abstract class SqlUtil {
   }
 
   /**
-   * Unparses a WHERE clause.
+   * Unparses a condition using a
+   * {@link SqlWriter.FrameTypeEnum#WHERE_LIST} frame, which provides
+   * predicate-list formatting.
    *
-   * <p>Unparsing the condition in a {@link SqlWriter.FrameTypeEnum#WHERE_LIST}
-   * frame lets sub-queries in predicates recognize that they need
-   * parentheses.
-   *
-   * @param writer   Writer
-   * @param where WHERE condition
+   * @param writer Writer
+   * @param condition Condition
    * @param leftPrec Left precedence
    * @param rightPrec Right precedence
    */
-  public static void unparseWhereClause(SqlWriter writer, SqlNode where,
-      int leftPrec, int rightPrec) {
-    writer.sep("WHERE");
-
+  public static void unparseConditionClause(SqlWriter writer,
+      SqlNode condition, int leftPrec, int rightPrec) {
     if (!writer.isAlwaysUseParentheses()) {
-      SqlNode node = where;
+      SqlNode node = condition;
 
       // Decide whether to split on ORs or ANDs.
-      SqlBinaryOperator whereSep = SqlStdOperatorTable.AND;
+      SqlBinaryOperator conditionSep = SqlStdOperatorTable.AND;
       if ((node instanceof SqlCall)
           && node.getKind() == SqlKind.OR) {
-        whereSep = SqlStdOperatorTable.OR;
+        conditionSep = SqlStdOperatorTable.OR;
       }
 
-      // Unroll whereClause.
+      // Unroll condition.
       final List<SqlNode> list = new ArrayList<>(0);
-      while (node.getKind() == whereSep.kind) {
+      while (node.getKind() == conditionSep.kind) {
         assert node instanceof SqlCall;
         final SqlCall call1 = (SqlCall) node;
         list.add(0, call1.operand(1));
@@ -490,10 +486,10 @@ public abstract class SqlUtil {
       }
       list.add(0, node);
 
-      writer.list(SqlWriter.FrameTypeEnum.WHERE_LIST, whereSep,
-          new SqlNodeList(list, where.getParserPosition()));
+      writer.list(SqlWriter.FrameTypeEnum.WHERE_LIST, conditionSep,
+          new SqlNodeList(list, condition.getParserPosition()));
     } else {
-      where.unparse(writer, leftPrec, rightPrec);
+      condition.unparse(writer, leftPrec, rightPrec);
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -10046,6 +10046,23 @@ class RelToSqlConverterTest {
     sql(sql7)
         .schema(CalciteAssert.SchemaSpec.JDBC_SCOTT)
         .ok(expected7);
+
+    // [CALCITE-7585] SqlMerge unparse EXISTS predicates in ON clause
+    // without parentheses.
+    final String sql8 = "merge into \"DEPT\" as \"t\"\n"
+        + "using \"DEPT\" as \"s\"\n"
+        + "on exists (select 1 from \"EMP\" as \"e\" where \"e\".\"DEPTNO\" = \"s\".\"DEPTNO\")\n"
+        + "when matched then\n"
+        + "update set \"DNAME\" = \"s\".\"DNAME\"";
+    final String expected8 = "MERGE INTO \"SCOTT\".\"DEPT\" AS \"DEPT0\"\n"
+        + "USING \"SCOTT\".\"DEPT\"\n"
+        + "ON EXISTS (SELECT *\n"
+        + "FROM \"SCOTT\".\"EMP\"\n"
+        + "WHERE \"DEPTNO\" = \"DEPT\".\"DEPTNO\")\n"
+        + "WHEN MATCHED THEN UPDATE SET \"DNAME\" = \"DEPT\".\"DNAME\"";
+    sql(sql8)
+        .schema(CalciteAssert.SchemaSpec.JDBC_SCOTT)
+        .ok(expected8);
   }
 
   /** Test case for


### PR DESCRIPTION


<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-7585](https://issues.apache.org/jira/browse/CALCITE-7585)

## Changes Proposed
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.
-->
Fixes unparsing of `EXISTS` predicates in the `ON` clause of `MERGE`.

`SqlMerge` was unparsing the `ON` condition directly. When the condition contains an `EXISTS` subquery, this can produce invalid SQL such as `ON EXISTS SELECT ...`.

This change adds `SqlUtil.unparseConditionClause` for unparsing conditions with the existing `WHERE_LIST` frame. `SELECT`, `UPDATE`, `DELETE`, and `MERGE` now emit their clause keyword explicitly and then use the shared helper for the condition.

Adds a regression test for `MERGE ... ON EXISTS (...)`.