### PR TITLE
Restore fixes reverted by [CALCITE-7580] Gandiva removal

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -529,11 +529,14 @@ public class RexSimplify {
       }
       if (e.operands.size() == 3 && e.operands.get(2) instanceof RexLiteral) {
         final RexLiteral escapeLiteral = (RexLiteral) e.operands.get(2);
-        Character escape = requireNonNull(escapeLiteral.getValueAs(Character.class));
-        e = (RexCall) rexBuilder
-            .makeCall(e.getParserPosition(), e.getOperator(), e.operands.get(0),
-                rexBuilder.makeLiteral(simplifyLikeString(likeStr, escape, '%'),
-                e.operands.get(1).getType(), true, true), escapeLiteral);
+        final String escapeStr = requireNonNull(escapeLiteral.getValueAs(String.class));
+        if (escapeStr.length() == 1) {
+          char escape = escapeStr.charAt(0);
+          e = (RexCall) rexBuilder
+              .makeCall(e.getParserPosition(), e.getOperator(), e.operands.get(0),
+                  rexBuilder.makeLiteral(simplifyLikeString(likeStr, escape, '%'),
+                      e.operands.get(1).getType(), true, true), escapeLiteral);
+        }
       }
     }
     return simplifyGenericNode(e);
@@ -543,7 +546,7 @@ public class RexSimplify {
   // string with even escapes 'AA\\\\%%__%%AA' simplify to 'AA\\__%AA'
   // string with odd escapes 'AA\\\\\\%%__%%AA' simplify to 'AA\\\\\\%__%AA'
   private String simplifyMixedWildcards(String str, char escape) {
-    Pattern pattern = Pattern.compile("[_%]+");
+    Pattern pattern = getWildCardPattern(escape);
     Matcher matcher = pattern.matcher(str);
     StringBuilder builder = new StringBuilder();
     int from = 0;
@@ -565,6 +568,17 @@ public class RexSimplify {
       builder.append(str.substring(from));
     }
     return builder.toString();
+  }
+
+  private static Pattern getWildCardPattern(char escape) {
+    switch (escape) {
+    case '%':
+      return Pattern.compile("_+");
+    case '_':
+      return Pattern.compile("%+");
+    default:
+      return Pattern.compile("[_%]+");
+    }
   }
 
   // Tool method: count the number of consecutive identical characters before index

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -561,7 +561,7 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
           }
         }
 
-        if (type.getSqlTypeName() == resultType.getSqlTypeName()
+        if (type.getSqlTypeName().getFamily() == resultType.getSqlTypeName().getFamily()
             && type.getSqlTypeName().allowsPrec()
             && type.getPrecision() != resultType.getPrecision()) {
           final int precision =

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -1870,7 +1870,7 @@ public class SqlToRelConverter {
       if (leftKeys.size() == 1) {
         SqlCall sqlCall =
             comparisonOp.createCall(rightVals.getParserPosition(), leftKeys.get(0), rightVals);
-        rexComparison = bb.convertExpression(sqlCall);
+        rexComparison = ensureComparisonTypes(bb.convertExpression(sqlCall));
       } else {
         assert rightVals instanceof SqlCall;
         final SqlBasicCall call = (SqlBasicCall) rightVals;
@@ -1880,9 +1880,10 @@ public class SqlToRelConverter {
             RexUtil.composeConjunction(rexBuilder,
                 transform(
                   Pair.zip(leftKeys, call.getOperandList()),
-                  pair -> bb.convertExpression(
-                        comparisonOp.createCall(rightVals.getParserPosition(),
-                            pair.left, pair.right))));
+                  pair -> ensureComparisonTypes(
+                      bb.convertExpression(
+                          comparisonOp.createCall(rightVals.getParserPosition(),
+                              pair.left, pair.right)))));
       }
       comparisons.add(rexComparison);
     }
@@ -1899,6 +1900,31 @@ public class SqlToRelConverter {
     default:
       throw new AssertionError();
     }
+  }
+
+  /**
+   * Ensures that a comparison expression has matching operand types. If the
+   * operands have different type names, casts the right operand to match the
+   * left operand's type. This handles the case where type coercion is disabled
+   * and the IN-to-OR expansion produces comparisons with mismatched types
+   * (e.g., DATE = CHAR).
+   */
+  private RexNode ensureComparisonTypes(RexNode node) {
+    if (validator != null && validator.config().typeCoercionEnabled()) {
+      return node;
+    }
+    if (node instanceof RexCall) {
+      final RexCall call = (RexCall) node;
+      if (call.operands.size() == 2) {
+        final RexNode left = call.operands.get(0);
+        final RexNode right = call.operands.get(1);
+        if (left.getType().getSqlTypeName() != right.getType().getSqlTypeName()) {
+          final RexNode castRight = rexBuilder.ensureType(left.getType(), right, true);
+          return rexBuilder.makeCall(call.getOperator(), left, castRight);
+        }
+      }
+    }
+    return node;
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -4358,6 +4358,10 @@ class RexProgramTest extends RexProgramTestBase {
    * Multiple consecutive '%' in the string matched by LIKE should simplify to a single '%'</a>,
    * <a href="https://issues.apache.org/jira/browse/CALCITE-7153">[CALCITE-7153]
    * Mixed wildcards of _ and % need to be simplified in LIKE operator</a>.
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7578">[CALCITE-7578]
+   * LIKE with empty ESCAPE might fail with StringIndexOutOfBoundsException</a>.
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7588">[CALCITE-7588]
+   * LIKE with ESCAPE symbols containing wildcards fails</a>.
    * */
   @Test void testSimplifyLike() {
     final RexNode ref = input(tVarchar(true, 10), 0);
@@ -4421,6 +4425,14 @@ class RexProgramTest extends RexProgramTestBase {
         "LIKE($0, '###%%#%#%A#%%#%A%###%%', '#')");
     checkSimplifyUnchanged(like(ref, literal("A"), literal("#")));
     checkSimplifyUnchanged(like(ref, literal("%A"), literal("#")));
+    checkSimplifyUnchanged(like(ref, literal("TE%_ST"), literal("%")));
+    checkSimplifyUnchanged(like(ref, literal("TE%%ST"), literal("%")));
+    checkSimplifyUnchanged(like(ref, literal("a%_b%%c"), literal("%")));
+    checkSimplifyUnchanged(like(ref, literal("%_%%A%_"), literal("%")));
+    // escape char equal to the '_' wildcard. '%E__S%' ESCAPE '_' is a literal '_'.
+    checkSimplifyUnchanged(like(ref, literal("%E__S%"), literal("_")));
+    checkSimplifyUnchanged(like(ref, literal("TE_%ST"), literal("_")));
+    checkSimplifyUnchanged(like(ref, literal("a_%b__c"), literal("_")));
 
     // As above, but ref is NOT NULL
     final RexNode refMandatory = vVarcharNotNull(0);
@@ -4451,6 +4463,14 @@ class RexProgramTest extends RexProgramTestBase {
     // NOT(SIMILAR TO) is not optimized
     checkSimplifyUnchanged(
         not(rexBuilder.makeCall(SqlStdOperatorTable.SIMILAR_TO, ref, literal("%"))));
+
+    try {
+      // Empty ESCAPE
+      checkSimplifyUnchanged(like(ref, literal("a"), literal("")));
+    } catch (RuntimeException e) {
+      assertThat(e.getMessage(),
+          containsString("Invalid escape character ''"));
+    }
   }
 
   @Test void testSimplifyNullCheckInFilter() {

--- a/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/type/SqlTypeFactoryTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasToString;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -169,6 +170,30 @@ class SqlTypeFactoryTest {
             Lists.newArrayList(f.sqlTimestampPrec3, f.sqlTimestampPrec0));
     assertThat(leastRestrictive.getSqlTypeName(), is(SqlTypeName.TIMESTAMP));
     assertThat(leastRestrictive.isNullable(), is(false));
+    assertThat(leastRestrictive.getPrecision(), is(3));
+  }
+
+  /**
+   * Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7567">
+   * LeastRetrictiveSqlType for TIMESTAMP, TIMESTAMP_LTZ might ignore precision</a>. */
+  @Test void testLeastRestrictiveForTimestampAndTimestampLtz() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType ltz0 =
+        f.typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 0);
+    RelDataType leastRestrictive =
+        f.typeFactory.leastRestrictive(Lists.newArrayList(ltz0, f.sqlTimestampPrec3));
+    assertThat(leastRestrictive, is(notNullValue()));
+    assertThat(leastRestrictive.getPrecision(), is(3));
+  }
+
+  @Test void testLeastRestrictiveForTimestampLtzAndTimestamp() {
+    SqlTypeFixture f = new SqlTypeFixture();
+    RelDataType ltz0 =
+        f.typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 0);
+    RelDataType leastRestrictive =
+        f.typeFactory.leastRestrictive(Lists.newArrayList(f.sqlTimestampPrec3, ltz0));
+    assertThat(leastRestrictive, is(notNullValue()));
     assertThat(leastRestrictive.getPrecision(), is(3));
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -2213,6 +2213,24 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).withExpand(false).ok();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7562">[CALCITE-7562]
+   * SqlToRel misses CAST in case IN expression without type coercion</a>. */
+  @Test void testInDateColumnWithoutTypeCoercion() {
+    final String sql =
+        "select * from emp_b where birthdate in ('2000-06-30', '2000-09-27')";
+    sql(sql).withTypeCoercion(false).ok();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7562">[CALCITE-7562]
+   * SqlToRel misses CAST in case IN expression without type coercion</a>. */
+  @Test void testInDateColumnWithTypeCoercion() {
+    final String sql =
+        "select * from emp_b where birthdate in ('2000-06-30', '2000-09-27')";
+    sql(sql).ok();
+  }
+
   @Test void testInValueListLong() {
     // Go over the default threshold of 20 to force a sub-query.
     final String sql = "select empno from emp where deptno in"

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -3308,6 +3308,30 @@ LogicalFilter(condition=[=($cor0.DEPTNO, $7)])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testInDateColumnWithTypeCoercion">
+    <Resource name="sql">
+      <![CDATA[select * from emp_b where birthdate in ('2000-06-30', '2000-09-27')]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], BIRTHDATE=[$9])
+  LogicalFilter(condition=[OR(=($9, CAST('2000-06-30'):DATE NOT NULL), =($9, CAST('2000-09-27'):DATE NOT NULL))])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testInDateColumnWithoutTypeCoercion">
+    <Resource name="sql">
+      <![CDATA[select * from emp_b where birthdate in ('2000-06-30', '2000-09-27')]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], BIRTHDATE=[$9])
+  LogicalFilter(condition=[OR(=($9, CAST('2000-06-30'):DATE NOT NULL), =($9, CAST('2000-09-27'):DATE NOT NULL))])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testInSubQueryWithTypeCast">
     <Resource name="sql">
       <![CDATA[select *

--- a/testkit/src/main/java/org/apache/calcite/test/SqlToRelFixture.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlToRelFixture.java
@@ -178,6 +178,11 @@ public class SqlToRelFixture {
             .withValidatorConfig(c -> c.withConformance(conformance)));
   }
 
+  public SqlToRelFixture withTypeCoercion(boolean enabled) {
+    return withFactory(f ->
+        f.withValidatorConfig(c -> c.withTypeCoercionEnabled(enabled)));
+  }
+
   public SqlToRelFixture withDiffRepos(DiffRepository diffRepos) {
     return new SqlToRelFixture(sql, decorrelate, tester, factory, trim,
         expression, diffRepos);


### PR DESCRIPTION
The merge of #4992 inadvertently reverted four fixes that had already landed on `main`.

## Cause

The CALCITE-7580 work originally branched from commit `39899bd18`, before the four fixes below were merged. During the later branch update/squash, the commit parent was moved to the newer `main`, but several Core and test files retained their contents from the older branch snapshot. Git therefore recorded those older file contents as intentional reverse changes against the new parent.

This was a branch-history/baseline issue, not an interaction between the Arrow adapter and Core behavior.

## Fix

This PR restores the accidentally reverted changes for:

- CALCITE-7562: preserve casts when expanding `IN` expressions with type coercion disabled
- CALCITE-7567: retain precision when finding a least-restrictive TIMESTAMP/TIMESTAMP_LTZ type
- CALCITE-7578: handle an empty `LIKE ... ESCAPE` string safely
- CALCITE-7588: handle wildcard characters used as the `LIKE` escape character

The Arrow/Gandiva changes from CALCITE-7580 remain unchanged.
