### PR TITLE
[CALCITE-7565] `TRIM` without `FROM` fails at parsing time

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -6953,9 +6953,16 @@ SqlNode BuiltinFunctionCall() :
                         flag = SqlTrimFunction.Flag.LEADING.symbol(getPos());
                     }
                 )
-                [ trimChars = Expression(ExprContext.ACCEPT_SUB_QUERY) ]
-                <FROM> { fromPos = getPos(); }
-                e = Expression(ExprContext.ACCEPT_SUB_QUERY)
+                (
+                    <FROM> { fromPos = getPos() ;}
+                    e = Expression(ExprContext.ACCEPT_SUB_QUERY)
+                |
+                    e = Expression(ExprContext.ACCEPT_SUB_QUERY)
+                    [
+                        <FROM> { trimChars = e; fromPos = getPos(); }
+                        e = Expression(ExprContext.ACCEPT_SUB_QUERY)
+                    ]
+                )
             )
             |
             (

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -5945,6 +5945,14 @@ public class SqlParserTest {
     // Parser accepts a call to TRIM() with no arguments
     expr("trim(^)^")
         .fails("(?s).*Encountered \"\\)\" at line 1, column 6\\..*");
+    // Test cases for [CALCITE-7565] https://issues.apache.org/jira/browse/CALCITE-7565
+    // TRIM without FROM fails at parsing time
+    expr("trim(both ' a ')")
+        .ok("TRIM(BOTH ' ' FROM ' a ')");
+    expr("trim(leading ' a ')")
+        .ok("TRIM(LEADING ' ' FROM ' a ')");
+    expr("trim(trailing ' a ')")
+        .ok("TRIM(TRAILING ' ' FROM ' a ')");
   }
 
   @Test void testConvertAndTranslate() {


### PR DESCRIPTION

## Jira Link

[CALCITE-7565](https://issues.apache.org/jira/browse/CALCITE-7565)

## Changes Proposed
The PRs makes queries with `TRIM` without `FROM` working again (as it was before Calcite 1.39.0)
probably as a result of CALCITE-6709 regression
