### PR TITLE
[CALCITE-7539] Upgrade Arrow adapter dependencies to 16.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -81,7 +81,7 @@ jandex.version=3.5.3
 # elasticsearch does not like asm:6.2.1+
 aggdesigner-algorithm.version=6.1
 apiguardian-api.version=1.1.2
-arrow.version=15.0.0
+arrow.version=16.0.0
 asm.version=9.9.1
 byte-buddy.version=1.18.8
 cassandra-all.version=4.1.6


### PR DESCRIPTION
This restores the Arrow dependency upgrade from 15.0.0 to 16.0.0 that was reverted in bc10595362b907c14a1b5302ae4740818bae6e50.

The upgrade was reverted together with the Gandiva-based implementation. Since [CALCITE-7580](https://issues.apache.org/jira/browse/CALCITE-7580) and #5030 removed the Gandiva dependency, the original compatibility issue no longer applies.

Tested with:

```
./gradlew :arrow:test --no-daemon
```