### PR TITLE
[CALCITE-7622] Don't fire JoinProjectTransposeRule for ANTI/SEMI/LEFT_MARK JOIN

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinProjectTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinProjectTransposeRule.java
@@ -112,6 +112,12 @@ public class JoinProjectTransposeRule
 
   //~ Methods ----------------------------------------------------------------
 
+  @Override public boolean matches(RelOptRuleCall call) {
+    Join join = call.rel(0);
+    // SEMI/ANTI/LEFT_MARK join cannot be swapped.
+    return join.getJoinType().projectsRight();
+  }
+
   @Override public void onMatch(RelOptRuleCall call) {
     final Join join = call.rel(0);
     final JoinRelType joinType = join.getJoinType();

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1517,6 +1517,43 @@ class RelOptRulesTest extends RelOptTestBase {
     relFn(relFn).withRule(CoreRules.PROJECT_JOIN_TRANSPOSE).check();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7622">[CALCITE-7622]
+   * Don't fire JoinProjectTransposeRule for ANTI/SEMI/LEFT_MARK JOIN</a>. */
+  @Test void testJoinProjectTransposeDoesNotMatchSemiJoin() {
+    checkJoinProjectTransposeDoesNotMatch(JoinRelType.SEMI);
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7622">[CALCITE-7622]
+   * Don't fire JoinProjectTransposeRule for ANTI/SEMI/LEFT_MARK JOIN</a>. */
+  @Test void testJoinProjectTransposeDoesNotMatchAntiJoin() {
+    checkJoinProjectTransposeDoesNotMatch(JoinRelType.ANTI);
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7622">[CALCITE-7622]
+   * Don't fire JoinProjectTransposeRule for ANTI/SEMI/LEFT_MARK JOIN</a>. */
+  @Test void testJoinProjectTransposeDoesNotMatchLeftMarkJoin() {
+    checkJoinProjectTransposeDoesNotMatch(JoinRelType.LEFT_MARK);
+  }
+
+  /** A SEMI, ANTI or LEFT_MARK join does not project its right input, so
+   * {@link JoinProjectTransposeRule} must not pull projects above it. */
+  private void checkJoinProjectTransposeDoesNotMatch(JoinRelType type) {
+    final Function<RelBuilder, RelNode> relFn = b -> b
+        .scan("EMP")
+        .project(b.field("DEPTNO"))
+        .scan("DEPT")
+        .project(b.field("DEPTNO"))
+        .join(type,
+            b.equals(
+                b.field(2, 0, 0),
+                b.field(2, 1, 0)))
+        .build();
+    relFn(relFn).withRule(CoreRules.JOIN_PROJECT_BOTH_TRANSPOSE).checkUnchanged();
+  }
+
   @Test void testJoinProjectTranspose1() {
     final String sql = "select a.name\n"
         + "from dept a\n"

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -8447,6 +8447,39 @@ LogicalProject(DEPTNO=[$0], NAME=[$1], NAME0=[$2], EXPR$1=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinProjectTransposeDoesNotMatchAntiJoin">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalJoin(condition=[=($0, $1)], joinType=[anti])
+  LogicalProject(DEPTNO=[$7])
+    LogicalTableScan(table=[[scott, EMP]])
+  LogicalProject(DEPTNO=[$0])
+    LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinProjectTransposeDoesNotMatchLeftMarkJoin">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalJoin(condition=[=($0, $1)], joinType=[left_mark])
+  LogicalProject(DEPTNO=[$7])
+    LogicalTableScan(table=[[scott, EMP]])
+  LogicalProject(DEPTNO=[$0])
+    LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinProjectTransposeDoesNotMatchSemiJoin">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalJoin(condition=[=($0, $1)], joinType=[semi])
+  LogicalProject(DEPTNO=[$7])
+    LogicalTableScan(table=[[scott, EMP]])
+  LogicalProject(DEPTNO=[$0])
+    LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinProjectTransposeWindow">
     <Resource name="sql">
       <![CDATA[select *


### PR DESCRIPTION
[[CALCITE-7622](https://issues.apache.org/jira/browse/CALCITE-7622)] Don't fire JoinProjectTransposeRule for ANTI/SEMI/LEFT_MARK JOIN