### PR TITLE
[CALCITE-7630] BETWEEN unparses incorrectly when left side contains a BETWEEN expression

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlStarReplace.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlStarReplace.java
@@ -76,7 +76,7 @@ public class SqlStarReplace extends SqlCall {
 
   @Override public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
     starIdentifier.unparse(writer, leftPrec, rightPrec);
-    writer.sep("REPLACE");
+    writer.keyword("REPLACE");
     final SqlWriter.Frame frame = writer.startList("(", ")");
     replaceList.unparse(writer, 0, 0);
     writer.endList(frame);

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlBetweenOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlBetweenOperator.java
@@ -269,6 +269,10 @@ public class SqlBetweenOperator extends SqlInfixOperator {
       if (operator == SqlStdOperatorTable.AND) {
         throw Util.FoundOne.NULL;
       }
+      // A BETWEEN expression contains an implicit AND keyword
+      if (call.getKind() == SqlKind.BETWEEN) {
+        throw Util.FoundOne.NULL;
+      }
       return super.visit(call);
     }
 

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlPrettyWriterTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlPrettyWriterTest.java
@@ -314,6 +314,15 @@ class SqlPrettyWriterTest {
     // space
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7630">[CALCITE-7630]
+   * BETWEEN unparses incorrectly when left side contains a BETWEEN expression</a>. */
+  @Test void testBetweenAnd3() {
+    expr("a not between (b between c and d) and e")
+        .expectingFormatted(
+            "`A` NOT BETWEEN ASYMMETRIC (`B` BETWEEN ASYMMETRIC `C` AND `D`) AND `E`")
+        .check();
+  }
+
   @Test void testCast() {
     expr("cast(x + y as decimal(5, 10))")
         .expectingFormatted("CAST(`X` + `Y` AS DECIMAL(5, 10))")

--- a/core/src/test/resources/org/apache/calcite/sql/test/SqlPrettyWriterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/sql/test/SqlPrettyWriterTest.xml
@@ -21,6 +21,11 @@
       <![CDATA[`X` NOT BETWEEN SYMMETRIC `Y` AND `Z`]]>
     </Resource>
   </TestCase>
+  <TestCase name="testBetweenAnd3">
+    <Resource name="formatted">
+      <![CDATA[`A` NOT BETWEEN ASYMMETRIC (`B` BETWEEN ASYMMETRIC `C` AND `D`) AND `E`]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testBlackSubQueryStyle">
     <Resource name="formatted">
       <![CDATA[SELECT `X` AS `A`, `B` AS `B`, `C` AS `C`, `D`, 'mixed-Case string', `UNQUOTEDCAMELCASEID`, `quoted id`


### PR DESCRIPTION
There are actually 2 commits, one fixing a smaller issue I didn't file a JIRA for.

## Jira Link

[CALCITE-7630](https://issues.apache.org/jira/browse/CALCITE-7630)
