### PR TITLE
Replace deprecated Stack with ArrayDeque in Pattern and TopDownRuleDriver

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/TopDownRuleDriver.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/TopDownRuleDriver.java
@@ -28,12 +28,13 @@ import org.apache.calcite.util.trace.CalciteTrace;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
@@ -47,7 +48,6 @@ import static java.util.Objects.requireNonNull;
  * A Task is a piece of work to be executed, it may apply some rules
  * or schedule other tasks.
  */
-@SuppressWarnings("JdkObsolete")
 class TopDownRuleDriver implements RuleDriver {
 
   private static final Logger LOGGER = CalciteTrace.getPlannerTaskTracer();
@@ -62,7 +62,7 @@ class TopDownRuleDriver implements RuleDriver {
   /**
    * All tasks waiting for execution.
    */
-  private final Stack<Task> tasks = new Stack<>(); // TODO: replace with Deque
+  private final Deque<Task> tasks = new ArrayDeque<>();
 
   /**
    * A task that is currently applying and may generate new RelNode.
@@ -350,7 +350,7 @@ class TopDownRuleDriver implements RuleDriver {
       for (RelNode rel : physicals) {
         Task task = getOptimizeInputTask(rel, group);
         if (task != null) {
-          tasks.add(task);
+          tasks.push(task);
         }
       }
     }
@@ -602,7 +602,7 @@ class TopDownRuleDriver implements RuleDriver {
                     requireNonNull(group.getTraitSet().getConvention(),
                         () -> "convention for " + group))));
     if (match != null) {
-      tasks.add(new ApplyRule(match, group, false));
+      tasks.push(new ApplyRule(match, group, false));
     }
     return null;
   }

--- a/core/src/main/java/org/apache/calcite/runtime/Pattern.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Pattern.java
@@ -18,7 +18,8 @@ package org.apache.calcite.runtime;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.Stack;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -68,9 +69,8 @@ public interface Pattern {
   }
 
   /** Builds a pattern expression. */
-  @SuppressWarnings("JdkObsolete")
   class PatternBuilder {
-    final Stack<Pattern> stack = new Stack<>(); // TODO: replace with Deque
+    final Deque<Pattern> stack = new ArrayDeque<>();
 
     private PatternBuilder() {}
 


### PR DESCRIPTION
## Summary

This PR addresses two explicit TODO comments requesting replacement of `java.util.Stack` with `java.util.Deque`.

## Changes

### Files Modified
- `core/src/main/java/org/apache/calcite/runtime/Pattern.java`
- `core/src/main/java/org/apache/calcite/plan/volcano/TopDownRuleDriver.java`

### Details
- Replaced `java.util.Stack` with `java.util.ArrayDeque` (via `Deque` interface)
- Removed `@SuppressWarnings("JdkObsolete")` annotations that were suppressing the deprecation warnings
- Removed the `// TODO: replace with Deque` comments
- Fixed two instances where `tasks.add()` was used instead of `tasks.push()` to maintain consistent LIFO behavior after the migration

### Why This Change?

`Stack` extends `Vector` and its operations are synchronized, which is unnecessary for single-threaded usage. `ArrayDeque` provides better performance and is the recommended replacement per Java documentation.

The `tasks.add()` → `tasks.push()` fix ensures semantic consistency: `Stack.add()` and `Stack.push()` both append to the end (LIFO), but `ArrayDeque.add()` appends to tail while `ArrayDeque.push()` adds to head. Without this fix, the migration would have changed behavior.