### PR TITLE
[CALCITE-7632] Replace java.util.Stack with java.util.ArrayDeque in Pattern and TopDownRuleDriver

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/TopDownRuleDriver.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/TopDownRuleDriver.java
@@ -28,12 +28,13 @@ import org.apache.calcite.util.trace.CalciteTrace;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Stack;
 import java.util.function.Predicate;
 
 import static java.util.Objects.requireNonNull;
@@ -47,7 +48,6 @@ import static java.util.Objects.requireNonNull;
  * A Task is a piece of work to be executed, it may apply some rules
  * or schedule other tasks.
  */
-@SuppressWarnings("JdkObsolete")
 class TopDownRuleDriver implements RuleDriver {
 
   private static final Logger LOGGER = CalciteTrace.getPlannerTaskTracer();
@@ -62,7 +62,7 @@ class TopDownRuleDriver implements RuleDriver {
   /**
    * All tasks waiting for execution.
    */
-  private final Stack<Task> tasks = new Stack<>(); // TODO: replace with Deque
+  private final Deque<Task> tasks = new ArrayDeque<>();
 
   /**
    * A task that is currently applying and may generate new RelNode.
@@ -350,7 +350,7 @@ class TopDownRuleDriver implements RuleDriver {
       for (RelNode rel : physicals) {
         Task task = getOptimizeInputTask(rel, group);
         if (task != null) {
-          tasks.add(task);
+          tasks.push(task);
         }
       }
     }
@@ -602,7 +602,7 @@ class TopDownRuleDriver implements RuleDriver {
                     requireNonNull(group.getTraitSet().getConvention(),
                         () -> "convention for " + group))));
     if (match != null) {
-      tasks.add(new ApplyRule(match, group, false));
+      tasks.push(new ApplyRule(match, group, false));
     }
     return null;
   }

--- a/core/src/main/java/org/apache/calcite/runtime/Pattern.java
+++ b/core/src/main/java/org/apache/calcite/runtime/Pattern.java
@@ -18,7 +18,8 @@ package org.apache.calcite.runtime;
 
 import com.google.common.collect.ImmutableList;
 
-import java.util.Stack;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -68,9 +69,8 @@ public interface Pattern {
   }
 
   /** Builds a pattern expression. */
-  @SuppressWarnings("JdkObsolete")
   class PatternBuilder {
-    final Stack<Pattern> stack = new Stack<>(); // TODO: replace with Deque
+    final Deque<Pattern> stack = new ArrayDeque<>();
 
     private PatternBuilder() {}
 


### PR DESCRIPTION
## Summary

Replace `java.util.Stack` with `java.util.ArrayDeque` in two locations, completing a TODO left in place since 2020.

## Background

In [CALCITE-4314](https://issues.apache.org/jira/browse/CALCITE-4314) (commit [e537246](https://github.com/apache/calcite/commit/e53724630af60566784e8aa7d8f56fe2932b12cc)), Vladimir Sitnikov enabled Error Prone checking for the Calcite codebase. As part of that effort, he identified 2 remaining `java.util.Stack` usages as obsolete and added `@SuppressWarnings("JdkObsolete")` with `// TODO: replace with Deque` to suppress warnings. The commit message explicitly stated *"It should be replaced with Deque"*, but the actual refactoring was deferred.

CALCITE-4314 was a broad static-analysis enablement issue — the Stack→Deque replacement was too granular to be tracked there specifically. This PR creates a dedicated issue (CALCITE-7632) to properly track and complete that deferred work.

## Changes

- **`core/src/main/java/org/apache/calcite/runtime/Pattern.java`**: `Stack<Pattern>` → `Deque<Pattern>` in `PatternBuilder.stack` field (used for SQL `MATCH_RECOGNIZE` NFA pattern matching)
- **`core/src/main/java/org/apache/calcite/plan/volcano/TopDownRuleDriver.java`**: `Stack<Task>` → `Deque<Task>` in task queue (used for Volcano optimizer top-down Cascades-style optimization)

Also removed the corresponding `@SuppressWarnings("JdkObsolete")` annotations and `// TODO: replace with Deque` comments.

## Rationale

- `java.util.Stack` extends `Vector` — all methods are `synchronized`, adding unnecessary lock overhead in single-threaded contexts
- `ArrayDeque` is non-synchronized, officially recommended by the Java documentation as a replacement for `Stack`
- Eliminates Error Prone `JdkObsolete` warnings without suppression
- Better memory expansion: `ArrayDeque` doubles capacity on resize vs `Vector`'s linear growth

## Testing

- Compilation: `BUILD SUCCESSFUL`
- Tests passed: AutomatonTest (9), DeterministicAutomatonTest (4), EnumerablesTest (53) — 0 failures
- No remaining `java.util.Stack` references in `core/src/main`

## Related

- JIRA: [CALCITE-7632](https://issues.apache.org/jira/browse/CALCITE-7632)
- Origin: [CALCITE-4314](https://issues.apache.org/jira/browse/CALCITE-4314) / commit [e537246](https://github.com/apache/calcite/commit/e53724630af60566784e8aa7d8f56fe2932b12cc)