### PR TITLE
[CALCITE-6344] RelToSqlConverter invalid quotation for arrays and item operator(ansi dialect)

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -713,9 +713,19 @@ public abstract class SqlImplementor {
           break;
         case ROW:
         case ITEM:
-          final SqlNode expr = toSql(program, referencedExpr);
-          sqlIdentifier = new SqlIdentifier(expr.toString(), POS);
-          break;
+          // The referenced expression (e.g. an array/map ITEM access) must be
+          // unparsed as its own SqlNode so that the target dialect quotes each
+          // part correctly. Combine it with the accessed field names using the
+          // DOT operator instead of collapsing everything into a single
+          // identifier name (which would get quoted as one token).
+          SqlNode dotNode = toSql(program, referencedExpr);
+          RexFieldAccess dotAccess;
+          while ((dotAccess = accesses.pollLast()) != null) {
+            dotNode =
+                SqlStdOperatorTable.DOT.createCall(POS, dotNode,
+                    new SqlIdentifier(dotAccess.getField().getName(), POS));
+          }
+          return dotNode;
         default:
           sqlIdentifier = (SqlIdentifier) toSql(program, referencedExpr);
         }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -2998,14 +2998,26 @@ class RelToSqlConverterTest {
    * SqlItemOperator fails in RelToSqlConverter</a>. */
   @Test void testSqlItemOperator() {
     sql("SELECT foo[0].\"EXPR$1\" FROM (SELECT ARRAY[ROW('a', 'b')] AS foo)")
-        .ok("SELECT \"ARRAY[ROW('a', 'b')][0]\".\"EXPR$1\"\n"
+        .ok("SELECT ARRAY[ROW('a', 'b')][0].\"EXPR$1\"\n"
             + "FROM (VALUES (0)) AS \"t\" (\"ZERO\")");
     sql("SELECT foo['k'].\"EXPR$1\" FROM (SELECT MAP['k', ROW('a', 'b')] AS foo)")
-        .ok("SELECT \"MAP['k', ROW('a', 'b')]['k']\".\"EXPR$1\"\n"
+        .ok("SELECT MAP['k', ROW('a', 'b')]['k'].\"EXPR$1\"\n"
             + "FROM (VALUES (0)) AS \"t\" (\"ZERO\")");
     sql("select\"books\"[0].\"title\" from \"authors\"")
         .schema(CalciteAssert.SchemaSpec.BOOKSTORE)
-        .ok("SELECT \"`books`[0]\".\"title\"\n"
+        .ok("SELECT \"books\"[0].\"title\"\n"
+            + "FROM \"bookstore\".\"authors\"");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6344">[CALCITE-6344]
+   * RelToSqlConverter invalid quotation for arrays and item operator
+   * (ansi dialect)</a>. */
+  @Test void testSqlItemOperator2() {
+    sql("SELECT \"books\"[0].\"title\" from \"bookstore\".\"authors\"")
+        .schema(CalciteAssert.SchemaSpec.BOOKSTORE)
+        .withPostgresql()
+        .ok("SELECT \"books\"[0].\"title\"\n"
             + "FROM \"bookstore\".\"authors\"");
   }
 


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/CALCITE-6344

The SQL generated by the dialect has been verified in PostgreSQL (the pre-fix version would have resulted in errors)：https://onecompiler.com/postgresql/44tvwz86e