### PR TITLE
Site: Update Ran Tao githubId

### DIFF
--- a/site/_data/contributors.yml
+++ b/site/_data/contributors.yml
@@ -292,7 +292,7 @@
   role: Committer
 - name: Ran Tao
   apacheId: taoran
-  githubId: chucheng92
+  githubId: taoran92
   pronouns: he/him
   org: ByteDance
   role: Committer


### PR DESCRIPTION
Ran Tao's profile picture is not displaying correctly on the official website; I noticed that his ID appears to have been updated, and I found his new ID in #3491.