### PR TITLE
Re-enable [CALCITE-685] Correlated scalar sub-query in SELECT clause throws

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -5500,7 +5500,6 @@ public class JdbcTest {
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-685">[CALCITE-685]
    * Correlated scalar sub-query in SELECT clause throws</a>. */
-  @Disabled("[CALCITE-685]")
   @Test void testCorrelatedScalarSubQuery() {
     final String sql = "select e.department_id, sum(e.employee_id),\n"
         + "       ( select sum(e2.employee_id)\n"
@@ -5508,19 +5507,35 @@ public class JdbcTest {
         + "         where e.department_id = e2.department_id\n"
         + "       )\n"
         + "from employee e\n"
-        + "group by e.department_id\n";
-    final String explain = "EnumerableNestedLoopJoin(condition=[true], joinType=[left])\n"
-        + "  EnumerableAggregate(group=[{7}], EXPR$1=[$SUM0($0)])\n"
-        + "    EnumerableTableScan(table=[[foodmart2, employee]])\n"
-        + "  EnumerableAggregate(group=[{}], EXPR$0=[SUM($0)])\n"
-        + "    EnumerableCalc(expr#0..16=[{inputs}], expr#17=[$cor0], expr#18=[$t17.department_id], expr#19=[=($t18, $t7)], employee_id=[$t0], department_id=[$t7], $condition=[$t19])\n"
-        + "      EnumerableTableScan(table=[[foodmart2, employee]])\n";
+        + "group by e.department_id\n"
+        + "order by e.department_id";
+    final String explain = "EnumerableCalc(expr#0..3=[{inputs}], proj#0..1=[{exprs}], "
+        + "EXPR$0=[$t3])\n"
+        + "  EnumerableMergeJoin(condition=[=($0, $2)], joinType=[left])\n"
+        + "    EnumerableSort(sort0=[$0], dir0=[ASC])\n"
+        + "      EnumerableAggregate(group=[{7}], EXPR$1=[$SUM0($0)])\n"
+        + "        EnumerableTableScan(table=[[foodmart2, employee]])\n"
+        + "    EnumerableSort(sort0=[$0], dir0=[ASC])\n"
+        + "      EnumerableAggregate(group=[{7}], EXPR$0=[$SUM0($0)])\n"
+        + "        EnumerableTableScan(table=[[foodmart2, employee]])\n";
     CalciteAssert.that()
         .with(CalciteAssert.Config.FOODMART_CLONE)
         .with(Lex.JAVA)
         .query(sql)
         .explainContains(explain)
-        .returnsCount(0);
+        .returnsOrdered(
+            "department_id=1; EXPR$1=75; EXPR$2=75",
+            "department_id=2; EXPR$1=160; EXPR$2=160",
+            "department_id=3; EXPR$1=126; EXPR$2=126",
+            "department_id=4; EXPR$1=87; EXPR$2=87",
+            "department_id=5; EXPR$1=398; EXPR$2=398",
+            "department_id=11; EXPR$1=44166; EXPR$2=44166",
+            "department_id=14; EXPR$1=8859; EXPR$2=8859",
+            "department_id=15; EXPR$1=133341; EXPR$2=133341",
+            "department_id=16; EXPR$1=160636; EXPR$2=160636",
+            "department_id=17; EXPR$1=137346; EXPR$2=137346",
+            "department_id=18; EXPR$1=165879; EXPR$2=165879",
+            "department_id=19; EXPR$1=17670; EXPR$2=17670");
   }
 
   @Test void testLeftJoin() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-685](https://issues.apache.org/jira/browse/CALCITE-685)
