### PR TITLE
[CALCITE-7634] JoinExpandOrToUnionRule incorrectly expands OR branches with non-equi predicates referencing both join inputs

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinExpandOrToUnionRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinExpandOrToUnionRule.java
@@ -29,6 +29,7 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.tools.RelBuilder;
 
 import org.immutables.value.Value;
@@ -155,10 +156,6 @@ public class JoinExpandOrToUnionRule
       // equality (when the above conditions are met), that are
       // single-side (refer to only on of the collections joined),
       // or which are constant, they will all trigger the expansion.
-      if (!doesNotReferToBothInputs(cond, leftFieldCount)) {
-        return false;
-      }
-
       if (RexUtil.SubQueryFinder.find(cond) != null
               || RexUtil.containsCorrelation(cond)) {
         // The "call" does not support sub-queries or correlation yet
@@ -170,7 +167,14 @@ public class JoinExpandOrToUnionRule
         // Checks if the "call" is valid for use as a join key.
         if (isEquiJoinCond(call, leftFieldCount)) {
           hasJoinKeyCond = true;
+          continue;
         }
+      }
+
+      // Non-equality predicates may be pushed into the expanded branch only
+      // if they do not correlate the two join inputs.
+      if (!doesNotReferToBothInputs(cond, leftFieldCount)) {
+        return false;
       }
     }
     return hasJoinKeyCond;
@@ -204,9 +208,9 @@ public class JoinExpandOrToUnionRule
   /**
    * Counts the number of InputRefs in a RexNode expression. */
   private static class RexInputRefCounter extends RexVisitorImpl<Void> {
-    private int leftFieldCount;
-    public int leftInputRefCount = 0;
-    public int rightInputRefCount = 0;
+    private final int leftFieldCount;
+    private int leftInputRefCount = 0;
+    private int rightInputRefCount = 0;
 
     RexInputRefCounter(int leftFieldCount) {
       super(true);
@@ -215,7 +219,7 @@ public class JoinExpandOrToUnionRule
 
     @Override public Void visitInputRef(RexInputRef inputRef) {
       if (inputRef.getIndex() < leftFieldCount) {
-        leftFieldCount++;
+        leftInputRefCount++;
       } else {
         rightInputRefCount++;
       }
@@ -367,7 +371,9 @@ public class JoinExpandOrToUnionRule
     for (int i = 0; i < orConds.size(); i++) {
       RexNode orCond = orConds.get(i);
       for (int j = 0; j < i; j++) {
-        orCond = relBuilder.and(orCond, relBuilder.not(orConds.get(j)));
+        orCond =
+            relBuilder.and(orCond,
+                relBuilder.call(SqlStdOperatorTable.IS_NOT_TRUE, orConds.get(j)));
       }
 
       relBuilder.push(join.getLeft())

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -10009,6 +10009,19 @@ class RelOptRulesTest extends RelOptTestBase {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7634">[CALCITE-7634]
+   * JoinExpandOrToUnionRule incorrectly expands OR branches with non-equi
+   * predicates referencing both join inputs</a>. */
+  @Test void testJoinConditionOrExpansionRuleWithCrossInputPredicate() {
+    String sql = "select * from EMP as p1\n"
+        + "inner join EMP as p2 on (p1.empno = p2.empno and p1.sal < p2.sal)\n"
+        + "or (p1.mgr = p2.mgr and p1.comm < p2.comm)\n"
+        + "or p1.deptno = p2.deptno";
+    sql(sql).withRule(CoreRules.JOIN_EXPAND_OR_TO_UNION_RULE)
+        .check();
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6930">[CALCITE-6930]
    * Implementing JoinConditionOrExpansionRule</a>. */
   @Test void testJoinConditionOrExpansionRuleMultiOr() {

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -7715,10 +7715,10 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
     LogicalJoin(condition=[AND(=($0, $9), =($2, 'Job1'), SEARCH($1, Sarg['a':VARCHAR(20), 'bb':VARCHAR(20), 'cc':VARCHAR(20)]:VARCHAR(20)), SEARCH($5, Sarg[(120..3000)]), =($3, $6))], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
       LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
-    LogicalJoin(condition=[AND(=($7, $16), =($11, 'Job2'), SEARCH($10, Sarg['a':VARCHAR(20), 'bb':VARCHAR(20), 'cc':VARCHAR(20)]:VARCHAR(20)), SEARCH($14, Sarg[(110..3000)]), <(CAST(+($3, 10)):DOUBLE, LN(15)), OR(<>($0, $9), <>($2, 'Job1'), SEARCH($1, Sarg[(-∞..'a':VARCHAR(20)), ('a':VARCHAR(20)..'bb':VARCHAR(20)), ('bb':VARCHAR(20)..'cc':VARCHAR(20)), ('cc':VARCHAR(20)..+∞)]:VARCHAR(20)), SEARCH($5, Sarg[(-∞..120], [3000..+∞)]), <>($3, $6)))], joinType=[inner])
+    LogicalJoin(condition=[AND(=($7, $16), =($11, 'Job2'), SEARCH($10, Sarg['a':VARCHAR(20), 'bb':VARCHAR(20), 'cc':VARCHAR(20)]:VARCHAR(20)), SEARCH($14, Sarg[(110..3000)]), <(CAST(+($3, 10)):DOUBLE, LN(15)), IS NOT TRUE(AND(=($0, $9), =($2, 'Job1'), SEARCH($1, Sarg['a':VARCHAR(20), 'bb':VARCHAR(20), 'cc':VARCHAR(20)]:VARCHAR(20)), SEARCH($5, Sarg[(120..3000)]), =($3, $6))))], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
       LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
-    LogicalJoin(condition=[AND(OR(AND(=($1, 'Jensen'), >($15, 10)), SEARCH(CAST($3):DECIMAL(11, 1), Sarg[[10.0:DECIMAL(11, 1)..20.0:DECIMAL(11, 1)]]:DECIMAL(11, 1))), OR(<>($0, $9), <>($2, 'Job1'), SEARCH($1, Sarg[(-∞..'a':VARCHAR(20)), ('a':VARCHAR(20)..'bb':VARCHAR(20)), ('bb':VARCHAR(20)..'cc':VARCHAR(20)), ('cc':VARCHAR(20)..+∞)]:VARCHAR(20)), SEARCH($5, Sarg[(-∞..120], [3000..+∞)]), <>($3, $6)), OR(<>($7, $16), <>($11, 'Job2'), SEARCH($10, Sarg[(-∞..'a':VARCHAR(20)), ('a':VARCHAR(20)..'bb':VARCHAR(20)), ('bb':VARCHAR(20)..'cc':VARCHAR(20)), ('cc':VARCHAR(20)..+∞)]:VARCHAR(20)), SEARCH($14, Sarg[(-∞..110], [3000..+∞)]), >=(CAST(+($3, 10)):DOUBLE, LN(15))))], joinType=[inner])
+    LogicalJoin(condition=[AND(OR(AND(=($1, 'Jensen'), >($15, 10)), SEARCH(CAST($3):DECIMAL(11, 1), Sarg[[10.0:DECIMAL(11, 1)..20.0:DECIMAL(11, 1)]]:DECIMAL(11, 1))), IS NOT TRUE(AND(=($0, $9), =($2, 'Job1'), SEARCH($1, Sarg['a':VARCHAR(20), 'bb':VARCHAR(20), 'cc':VARCHAR(20)]:VARCHAR(20)), SEARCH($5, Sarg[(120..3000)]), =($3, $6))), IS NOT TRUE(AND(=($7, $16), =($11, 'Job2'), SEARCH($10, Sarg['a':VARCHAR(20), 'bb':VARCHAR(20), 'cc':VARCHAR(20)]:VARCHAR(20)), SEARCH($14, Sarg[(110..3000)]), <(CAST(+($3, 10)):DOUBLE, LN(15)))))], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
       LogicalTableScan(table=[[CATALOG, SALES, EMPNULLABLES]])
 ]]>
@@ -7756,7 +7756,7 @@ LogicalUnion(all=[true])
   LogicalJoin(condition=[=($0, $10)], joinType=[inner])
     LogicalTableScan(table=[[scott, DEPT]])
     LogicalTableScan(table=[[scott, EMP]])
-  LogicalJoin(condition=[AND(=($1, $5), <>($0, $10))], joinType=[inner])
+  LogicalJoin(condition=[AND(=($1, $5), IS NOT TRUE(=($0, $10)))], joinType=[inner])
     LogicalTableScan(table=[[scott, DEPT]])
     LogicalTableScan(table=[[scott, EMP]])
   LogicalProject($f0=[null:TINYINT], $f1=[null:VARCHAR(14)], $f2=[null:VARCHAR(13)], EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7])
@@ -7829,10 +7829,10 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
     LogicalJoin(condition=[<($3, $12)], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-    LogicalJoin(condition=[AND(=($0, $9), >=($3, $12))], joinType=[inner])
+    LogicalJoin(condition=[AND(=($0, $9), IS NOT TRUE(<($3, $12)))], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
-    LogicalJoin(condition=[AND(OR(<($5, 0), <(LN($5), 10.0E0)), >=($3, $12), <>($0, $9))], joinType=[inner])
+    LogicalJoin(condition=[AND(OR(<($5, 0), <(LN($5), 10.0E0)), IS NOT TRUE(<($3, $12)), <>($0, $9))], joinType=[inner])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
       LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
@@ -7868,6 +7868,34 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
           LogicalTableScan(table=[[CATALOG, SALES, DEPT]])
           LogicalTableScan(table=[[CATALOG, SALES, EMP]])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinConditionOrExpansionRuleWithCrossInputPredicate">
+    <Resource name="sql">
+      <![CDATA[select * from EMP as p1
+inner join EMP as p2 on (p1.empno = p2.empno and p1.sal < p2.sal)
+or (p1.mgr = p2.mgr and p1.comm < p2.comm)
+or p1.deptno = p2.deptno]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EMPNO0=[$9], ENAME0=[$10], JOB0=[$11], MGR0=[$12], HIREDATE0=[$13], SAL0=[$14], COMM0=[$15], DEPTNO0=[$16], SLACKER0=[$17])
+  LogicalJoin(condition=[OR(AND(=($0, $9), <($5, $14)), AND(=($3, $12), <($6, $15)), =($7, $16))], joinType=[inner])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], EMPNO0=[$9], ENAME0=[$10], JOB0=[$11], MGR0=[$12], HIREDATE0=[$13], SAL0=[$14], COMM0=[$15], DEPTNO0=[$16], SLACKER0=[$17])
+  LogicalUnion(all=[true])
+    LogicalJoin(condition=[OR(AND(=($0, $9), <($5, $14)), AND(=($3, $12), <($6, $15)))], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+    LogicalJoin(condition=[AND(=($7, $16), IS NOT TRUE(OR(AND(=($0, $9), <($5, $14)), AND(=($3, $12), <($6, $15)))))], joinType=[inner])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+      LogicalTableScan(table=[[CATALOG, SALES, EMP]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/sql/hep.iq
+++ b/core/src/test/resources/sql/hep.iq
@@ -238,6 +238,44 @@ EnumerableHashJoin(condition=[AND(=($0, $6), OR(AND(>($1, 11), <=($7, 32)), AND(
 !}
 !set hep-rules original
 
+# [CALCITE-7634] JoinExpandOrToUnionRule incorrectly expands OR branches with non-equi predicates referencing both join inputs
+!set hep-rules "
++CoreRules.JOIN_EXPAND_OR_TO_UNION_RULE"
+
+with emp_nulls (empno, mgr, sal, comm, deptno) as (values
+  (1, 10, 100, cast(null as integer), 20),
+  (2, 10, 200, 5, 20),
+  (3, 30, 300, cast(null as integer), 30))
+select p1.empno as e1, p2.empno as e2
+from emp_nulls as p1
+inner join emp_nulls as p2 on (p1.empno = p2.empno and p1.sal < p2.sal)
+or (p1.mgr = p2.mgr and p1.comm < p2.comm)
+or p1.deptno = p2.deptno
+order by e1, e2;
++----+----+
+| E1 | E2 |
++----+----+
+|  1 |  1 |
+|  1 |  2 |
+|  2 |  1 |
+|  2 |  2 |
+|  3 |  3 |
++----+----+
+(5 rows)
+
+!ok
+EnumerableSort(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[ASC])
+  EnumerableCalc(expr#0..9=[{inputs}], E1=[$t0], E2=[$t5])
+    EnumerableUnion(all=[true])
+      EnumerableNestedLoopJoin(condition=[OR(AND(=($0, $5), <($2, $7)), AND(=($1, $6), <($3, $8)))], joinType=[inner])
+        EnumerableValues(tuples=[[{ 1, 10, 100, null, 20 }, { 2, 10, 200, 5, 20 }, { 3, 30, 300, null, 30 }]])
+        EnumerableValues(tuples=[[{ 1, 10, 100, null, 20 }, { 2, 10, 200, 5, 20 }, { 3, 30, 300, null, 30 }]])
+      EnumerableMergeJoin(condition=[AND(=($4, $9), IS NOT TRUE(OR(AND(=($0, $5), <($2, $7)), AND(=($1, $6), <($3, $8)))))], joinType=[inner])
+        EnumerableValues(tuples=[[{ 1, 10, 100, null, 20 }, { 2, 10, 200, 5, 20 }, { 3, 30, 300, null, 30 }]])
+        EnumerableValues(tuples=[[{ 1, 10, 100, null, 20 }, { 2, 10, 200, 5, 20 }, { 3, 30, 300, null, 30 }]])
+!plan
+!set hep-rules original
+
 # [CALCITE-5740] Support for AggToSemiJoinRule
 !set hep-rules "
 +CoreRules.AGGREGATE_PROJECT_MERGE,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-7634](https://issues.apache.org/jira/browse/CALCITE-7634)

