### PR TITLE
Escape single quotes in string literals pushed to Cassandra and Geode

### DIFF
--- a/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraFilter.java
+++ b/cassandra/src/main/java/org/apache/calcite/adapter/cassandra/CassandraFilter.java
@@ -302,7 +302,7 @@ public class CassandraFilter extends Filter implements CassandraRel {
             requireNonNull(rowType.getField(name, true, false));
         SqlTypeName typeName = field.getType().getSqlTypeName();
         if (typeName != SqlTypeName.CHAR) {
-          valueString = "'" + valueString + "'";
+          valueString = "'" + valueString.replace("'", "''") + "'";
         }
       }
       return name + " " + op + " " + valueString;

--- a/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
+++ b/cassandra/src/test/java/org/apache/calcite/test/CassandraAdapterTest.java
@@ -71,6 +71,15 @@ class CassandraAdapterTest {
            + "    CassandraTableScan(table=[[twissandra, userline]]");
   }
 
+  @Test void testFilterWithSingleQuote() {
+    // A string literal containing a single quote must be escaped so it does not
+    // break out of the CQL string literal in the generated query.
+    CalciteAssert.that()
+        .with(TWISSANDRA)
+        .query("select * from \"userline\" where \"username\" = 'a''b'")
+        .returnsCount(0);
+  }
+
   @Test void testFilterUUID() {
     CalciteAssert.that()
         .with(TWISSANDRA)

--- a/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeFilter.java
+++ b/geode/src/main/java/org/apache/calcite/adapter/geode/rel/GeodeFilter.java
@@ -395,7 +395,7 @@ public class GeodeFilter extends Filter implements GeodeRel {
     private static String quoteCharLiteral(RexLiteral literal) {
       String value = literalValue(literal);
       if (literal.getTypeName() == CHAR) {
-        value = "'" + value + "'";
+        value = "'" + value.replace("'", "''") + "'";
       }
       return value;
     }

--- a/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeZipsTest.java
+++ b/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeZipsTest.java
@@ -213,6 +213,20 @@ class GeodeZipsTest extends AbstractGeodeTest {
             GeodeAssertions.query(expectedQuery));
   }
 
+  /** Value that already contains adjacent single quotes: the literal {@code 'I''''m fine'}
+   * denotes the runtime value {@code I''m fine}, and every embedded quote is doubled so the
+   * OQL round-trips back to that same value. */
+  @Test void testFilterWithAdjacentSingleQuoteLiteral() {
+    String expectedQuery = "SELECT city AS city FROM /zips "
+        + "WHERE city = 'I''''m fine'";
+    calciteAssert()
+        .query("SELECT city as city "
+            + "FROM view WHERE city = 'I''''m fine'")
+        .returnsCount(0)
+        .queryContains(
+            GeodeAssertions.query(expectedQuery));
+  }
+
   @Test void testWhereWithOrForNumericField() {
     calciteAssert()
         .query("SELECT pop as pop "

--- a/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeZipsTest.java
+++ b/geode/src/test/java/org/apache/calcite/adapter/geode/rel/GeodeZipsTest.java
@@ -202,6 +202,17 @@ class GeodeZipsTest extends AbstractGeodeTest {
             GeodeAssertions.query(expectedQuery));
   }
 
+  @Test void testFilterWithSingleQuoteLiteral() {
+    String expectedQuery = "SELECT city AS city FROM /zips "
+        + "WHERE city = 'a''b'";
+    calciteAssert()
+        .query("SELECT city as city "
+            + "FROM view WHERE city = 'a''b'")
+        .returnsCount(0)
+        .queryContains(
+            GeodeAssertions.query(expectedQuery));
+  }
+
   @Test void testWhereWithOrForNumericField() {
     calciteAssert()
         .query("SELECT pop as pop "


### PR DESCRIPTION
## Jira Link

No Jira filed yet; happy to open one under CALCITE if you'd prefer to track it there.

## Changes Proposed

When the Cassandra and Geode adapters push a filter down to the backend, a SQL string literal is wrapped in single quotes to build the CQL/OQL predicate, but embedded single quotes are not escaped. `CassandraFilter.translateOp2` and `GeodeFilter.quoteCharLiteral` emit `col = '<value>'` verbatim, so a value that itself contains a quote breaks out of the string literal. A legitimate value such as `O'Brien` produces malformed CQL/OQL, and a runtime-supplied literal can inject additional predicate syntax into the query that reaches `session.execute` / `QueryService.newQuery`.

The Geode test for `WHERE city = 'a''b'` currently makes the OQL parser fail with `unexpected token: b`, which shows the value leaking out of the literal. Doubling the embedded quote (`'` -> `''`) keeps the value inside the literal for both dialects; this is the same escaping the Druid adapter already applies in `DruidExpressions.stringLiteral`.

Added a Geode test that asserts the generated OQL is `... WHERE city = 'a''b'`, and a Cassandra test that a quoted filter value executes cleanly.
