### PR TITLE
[CALCITE-7206] Avoid duplicate compare(Object, Object) bridge method in the Enumerable merge join comparator

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysTypeImpl.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/PhysTypeImpl.java
@@ -499,7 +499,10 @@ public class PhysTypeImpl implements PhysType {
                 ImmutableList.of(parameterV0, parameterV1),
                 body.toBlock()));
 
-    if (EnumerableRules.BRIDGE_METHODS) {
+    // When javaRowClass is Object the primary compare method already has the
+    // signature compare(Object, Object), so a bridge method would be a
+    // duplicate and the generated Comparator would fail to compile.
+    if (EnumerableRules.BRIDGE_METHODS && javaRowClass != Object.class) {
       final ParameterExpression parameterO0 =
           Expressions.parameter(Object.class, "o0");
       final ParameterExpression parameterO1 =

--- a/core/src/test/java/org/apache/calcite/adapter/enumerable/PhysTypeTest.java
+++ b/core/src/test/java/org/apache/calcite/adapter/enumerable/PhysTypeTest.java
@@ -21,6 +21,8 @@ import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.SqlTypeName;
 
@@ -29,7 +31,9 @@ import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 
 /**
  * Test for {@link org.apache.calcite.adapter.enumerable.PhysTypeImpl}.
@@ -97,5 +101,34 @@ public final class PhysTypeTest {
         + "}\n"
         + ")";
     assertThat(expected, is(Expressions.toString(e)));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7206">[CALCITE-7206]
+   * Duplicate 'compare' method in the Enumerable merge join comparator when the
+   * row Java class is Object</a>.
+   *
+   * <p>When the row is a single column whose Java class is {@link Object} (for
+   * example a merge join key of type {@code ANY}), the primary
+   * {@code compare(Object, Object)} method and the generated bridge method have
+   * the same signature, so the emitted {@link java.util.Comparator} must not
+   * declare the bridge method twice or it fails to compile. */
+  @Test void testMergeJoinComparatorWithObjectRowHasNoDuplicateBridge() {
+    final RelDataType rowType =
+        TYPE_FACTORY.createStructType(
+            ImmutableList.of(
+                TYPE_FACTORY.createSqlType(SqlTypeName.ANY)),
+            ImmutableList.of("anyField"));
+    final PhysType rowPhysType =
+        PhysTypeImpl.of(TYPE_FACTORY, rowType, JavaRowFormat.SCALAR, false);
+    final RelCollation collation = RelCollations.of(0);
+    final Expression comparator =
+        rowPhysType.generateMergeJoinComparator(collation);
+    final String generated = Expressions.toString(comparator);
+    // The primary compare method is still generated ...
+    assertThat(generated, containsString("public int compare(Object v0, Object v1)"));
+    // ... but the bridge compare(Object o0, Object o1) would collide with it and
+    // must therefore be omitted.
+    assertThat(generated, not(containsString("Object o0, Object o1")));
   }
 }


### PR DESCRIPTION

## Jira Link

[CALCITE-7206](https://issues.apache.org/jira/browse/CALCITE-7206)

## Changes Proposed

`PhysTypeImpl.generateComparator` always appends a bridge
`compare(Object, Object)` method to the generated `Comparator` when
`EnumerableRules.BRIDGE_METHODS` is enabled (the default). The bridge exists so
the erased `Comparator.compare(Object, Object)` interface method delegates to the
strongly typed primary `compare(rowClass, rowClass)` method.

When the row is a single column whose Java class is already `Object` (for
example a merge join whose key has type `ANY`, materialized as a bare `Object`),
the primary method's boxed signature is `compare(Object, Object)`, which is
identical to the bridge. The emitted `Comparator` then declares two
`compare(Object, Object)` methods and Janino fails to compile it with `Error
while compiling generated Java code`. This reproduces on an `EnumerableMergeJoin`
with an `Object`-typed join key, as reported on the Jira.

This change guards the bridge block with `javaRowClass != Object.class`: when the
boxed row class is already `Object`, the primary `compare` method already
satisfies the `Comparator` contract, so no bridge is needed and none is emitted.
For every other row class (the common `Object[]` row and all primitive-boxed
rows) the boxed class differs from `Object`, so the bridge is still generated and
behavior is unchanged.

The same private `generateComparator` also backs the comparators used by
`EnumerableWindow`, `EnumerableAsofJoin`, and `EnumerableSortedAggregate`, so
each of those paths would have hit the identical duplicate-method failure on an
`Object` row and is fixed by the same guard.

Added a focused unit test in `PhysTypeTest`,
`testMergeJoinComparatorWithObjectRowHasNoDuplicateBridge`, that builds the
reported shape (a single-column `ANY` struct with `JavaRowFormat.SCALAR`, so the
row Java class is `Object`), calls `generateMergeJoinComparator`, and asserts the
generated source keeps the primary `compare(Object v0, Object v1)` method but no
longer contains the colliding bridge parameters. The test fails on `main` with
the duplicate bridge method and passes with this change.

`./gradlew :core:test --tests
"org.apache.calcite.adapter.enumerable.PhysTypeTest"` and `./gradlew :core:test
--tests "org.apache.calcite.test.enumerable.EnumerableJoinTest"` pass, and
`autostyleCheck` / `checkstyleMain` / `checkstyleTest` are clean.
