### PR TITLE
[CALCITE-7644] Window `ORDER BY` expression is unparsed as positional ordinal

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1077,7 +1077,8 @@ public abstract class SqlImplementor {
         partitionKeys.add(this.field(partition));
       }
       for (RelFieldCollation collation : group.orderKeys.getFieldCollations()) {
-        this.addOrderItem(orderByKeys, collation);
+        // A window ORDER BY has no ordinal notion; resolve via field().
+        this.addOrderItem(orderByKeys, collation, false);
       }
       SqlLiteral isRows = SqlLiteral.createBoolean(group.isRows, POS);
       SqlNode lowerBound = null;
@@ -1290,6 +1291,15 @@ public abstract class SqlImplementor {
     }
 
     void addOrderItem(List<SqlNode> orderByList, RelFieldCollation field) {
+      addOrderItem(orderByList, field, true);
+    }
+
+    /** Adds an ORDER BY item, optionally allowing an expression key to be
+     * emitted as a positional ordinal. Ordinals are valid only in a
+     * statement-level ORDER BY; callers such as a window's ORDER BY must pass
+     * {@code allowsOrdinal = false}. */
+    void addOrderItem(List<SqlNode> orderByList, RelFieldCollation field,
+        boolean allowsOrdinal) {
       if (field.nullDirection != RelFieldCollation.NullDirection.UNSPECIFIED) {
         final boolean first =
             field.nullDirection == RelFieldCollation.NullDirection.FIRST;
@@ -1303,7 +1313,7 @@ public abstract class SqlImplementor {
                   RelFieldCollation.NullDirection.UNSPECIFIED);
         }
       }
-      orderByList.add(toSql(field));
+      orderByList.add(toSql(field, allowsOrdinal));
     }
 
     /** Converts a RexFieldCollation to an ORDER BY item. */
@@ -1426,7 +1436,15 @@ public abstract class SqlImplementor {
 
     /** Converts a collation to an ORDER BY item. */
     public SqlNode toSql(RelFieldCollation collation) {
-      SqlNode node = orderField(collation.getFieldIndex());
+      return toSql(collation, true);
+    }
+
+    /** Converts a collation to an ORDER BY item; see
+     * {@link #addOrderItem(List, RelFieldCollation, boolean)}. */
+    public SqlNode toSql(RelFieldCollation collation, boolean allowsOrdinal) {
+      SqlNode node = allowsOrdinal
+          ? orderField(collation.getFieldIndex())
+          : field(collation.getFieldIndex());
       switch (collation.getDirection()) {
       case DESCENDING:
       case STRICTLY_DESCENDING:

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1118,7 +1118,8 @@ public abstract class SqlImplementor {
         partitionKeys.add(this.field(partition));
       }
       for (RelFieldCollation collation : group.orderKeys.getFieldCollations()) {
-        this.addOrderItem(orderByKeys, collation);
+        // A window ORDER BY has no ordinal notion; resolve via field().
+        this.addOrderItem(orderByKeys, collation, false);
       }
       SqlLiteral isRows = SqlLiteral.createBoolean(group.isRows, POS);
       SqlNode lowerBound = null;
@@ -1331,6 +1332,15 @@ public abstract class SqlImplementor {
     }
 
     void addOrderItem(List<SqlNode> orderByList, RelFieldCollation field) {
+      addOrderItem(orderByList, field, true);
+    }
+
+    /** Adds an ORDER BY item, optionally allowing an expression key to be
+     * emitted as a positional ordinal. Ordinals are valid only in a
+     * statement-level ORDER BY; callers such as a window's ORDER BY must pass
+     * {@code allowsOrdinal = false}. */
+    void addOrderItem(List<SqlNode> orderByList, RelFieldCollation field,
+        boolean allowsOrdinal) {
       if (field.nullDirection != RelFieldCollation.NullDirection.UNSPECIFIED) {
         final boolean first =
             field.nullDirection == RelFieldCollation.NullDirection.FIRST;
@@ -1344,7 +1354,7 @@ public abstract class SqlImplementor {
                   RelFieldCollation.NullDirection.UNSPECIFIED);
         }
       }
-      orderByList.add(toSql(field));
+      orderByList.add(toSql(field, allowsOrdinal));
     }
 
     /** Converts a RexFieldCollation to an ORDER BY item. */
@@ -1467,7 +1477,15 @@ public abstract class SqlImplementor {
 
     /** Converts a collation to an ORDER BY item. */
     public SqlNode toSql(RelFieldCollation collation) {
-      SqlNode node = orderField(collation.getFieldIndex());
+      return toSql(collation, true);
+    }
+
+    /** Converts a collation to an ORDER BY item; see
+     * {@link #addOrderItem(List, RelFieldCollation, boolean)}. */
+    public SqlNode toSql(RelFieldCollation collation, boolean allowsOrdinal) {
+      SqlNode node = allowsOrdinal
+          ? orderField(collation.getFieldIndex())
+          : field(collation.getFieldIndex());
       switch (collation.getDirection()) {
       case DESCENDING:
       case STRICTLY_DESCENDING:

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -5985,6 +5985,32 @@ class RelToSqlConverterTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7644">[CALCITE-7644]
+   *  Window's ORDER BY expression is unparsed as positional ordinal</a>. */
+  @Test void testWindowOrderByExpression() {
+    // A window ORDER BY expression must not be unparsed as a positional ordinal.
+    final String query = "SELECT \"employee_id\", \"salary\", \"hire_date\", "
+        + "SUM(\"salary\") OVER ("
+        + "PARTITION BY \"employee_id\" "
+        + "ORDER BY CASE WHEN \"salary\" > 1000 THEN 1 ELSE 0 END "
+        + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"sum_val\"\n"
+        + "FROM \"employee\"";
+    final String expected = "SELECT \"employee_id\", \"salary\", \"hire_date\", "
+        + "SUM(\"salary\") OVER (PARTITION BY \"employee_id\" "
+        + "ORDER BY CASE WHEN CAST(\"salary\" AS DECIMAL(14, 4)) > 1000.0000 "
+        + "THEN 1 ELSE 0 END "
+        + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"sum_val\"\n"
+        + "FROM \"foodmart\".\"employee\"";
+
+    final HepProgramBuilder builder = new HepProgramBuilder();
+    builder.addRuleClass(ProjectToWindowRule.class);
+    final HepPlanner hepPlanner = new HepPlanner(builder.build());
+    final RuleSet rules =
+        RuleSets.ofList(CoreRules.PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW);
+    sql(query).optimize(rules, hepPlanner).ok(expected);
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6475">[CALCITE-6475]
    * RelToSql converter fails when the IN-list contains NULL
    * and it is converted to VALUES</a>. */

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -6151,6 +6151,32 @@ class RelToSqlConverterTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7644">[CALCITE-7644]
+   *  Window's ORDER BY expression is unparsed as positional ordinal</a>. */
+  @Test void testWindowOrderByExpression() {
+    // A window ORDER BY expression must not be unparsed as a positional ordinal.
+    final String query = "SELECT \"employee_id\", \"salary\", \"hire_date\", "
+        + "SUM(\"salary\") OVER ("
+        + "PARTITION BY \"employee_id\" "
+        + "ORDER BY CASE WHEN \"salary\" > 1000 THEN 1 ELSE 0 END "
+        + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"sum_val\"\n"
+        + "FROM \"employee\"";
+    final String expected = "SELECT \"employee_id\", \"salary\", \"hire_date\", "
+        + "SUM(\"salary\") OVER (PARTITION BY \"employee_id\" "
+        + "ORDER BY CASE WHEN CAST(\"salary\" AS DECIMAL(14, 4)) > 1000.0000 "
+        + "THEN 1 ELSE 0 END "
+        + "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS \"sum_val\"\n"
+        + "FROM \"foodmart\".\"employee\"";
+
+    final HepProgramBuilder builder = new HepProgramBuilder();
+    builder.addRuleClass(ProjectToWindowRule.class);
+    final HepPlanner hepPlanner = new HepPlanner(builder.build());
+    final RuleSet rules =
+        RuleSets.ofList(CoreRules.PROJECT_TO_LOGICAL_PROJECT_AND_WINDOW);
+    sql(query).optimize(rules, hepPlanner).ok(expected);
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6475">[CALCITE-6475]
    * RelToSql converter fails when the IN-list contains NULL
    * and it is converted to VALUES</a>. */


### PR DESCRIPTION

## Jira Link

[CALCITE-7644](https://issues.apache.org/jira/browse/CALCITE-7644)

## Changes Proposed
in case of `OVER(...)` window's `ORDER BY` should be passed as a field expression rather than positional ordinal (also see jira issue description)
