### PR TITLE
[CALCITE-7645] AggregateUnionTransposeRule drops aggregate FILTER when rebuilding child aggregate calls

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/AggregateUnionTransposeRule.java
@@ -166,8 +166,9 @@ public class AggregateUnionTransposeRule
           AggregateCall newCall =
               AggregateCall.create(origCall.getParserPosition(), origCall.getAggregation(),
                   origCall.isDistinct(), origCall.isApproximate(), origCall.ignoreNulls(),
-                  origCall.rexList, origCall.getArgList(), -1, origCall.distinctKeys,
-                  origCall.collation, aggRel.getGroupSet().isEmpty(), input, null,
+                  origCall.rexList, origCall.getArgList(), origCall.filterArg,
+                  origCall.distinctKeys, origCall.collation,
+                  aggRel.getGroupSet().isEmpty(), input, null,
                   origCall.getName());
           childAggCalls.set(i, newCall);
         }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -8641,6 +8641,22 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7645">[CALCITE-7645]
+   * AggregateUnionTransposeRule drops aggregate FILTER when rebuilding
+   * pushed-down aggregate calls</a>. */
+  @Test void testAggregateUnionTransposeWithFilterAndNullableInput() {
+    final String sql = "select min(v) filter (where p)\n"
+        + "from (\n"
+        + "  select * from (values (10, false), (100, true)) as t(v, p)\n"
+        + "  union all\n"
+        + "  select * from (values (cast(null as integer), true), (200, true)) as t(v, p)\n"
+        + ")";
+    sql(sql)
+        .withRule(CoreRules.AGGREGATE_UNION_TRANSPOSE)
+        .check();
+  }
+
   /** If all inputs to UNION are already unique, AggregateUnionTransposeRule is
    * a no-op. */
   @Test void testAggregateUnionTransposeWithAllInputsUnique() {

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -1311,6 +1311,38 @@ LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testAggregateUnionTransposeWithFilterAndNullableInput">
+    <Resource name="sql">
+      <![CDATA[select min(v) filter (where p)
+from (
+  select * from (values (10, false), (100, true)) as t(v, p)
+  union all
+  select * from (values (cast(null as integer), true), (200, true)) as t(v, p)
+)]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0) FILTER $1])
+  LogicalUnion(all=[true])
+    LogicalProject(V=[$0], P=[$1])
+      LogicalValues(tuples=[[{ 10, false }, { 100, true }]])
+    LogicalProject(V=[$0], P=[$1])
+      LogicalValues(tuples=[[{ null, true }, { 200, true }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[MIN($0)])
+  LogicalUnion(all=[true])
+    LogicalAggregate(group=[{}], EXPR$0=[MIN($0) FILTER $1])
+      LogicalProject(V=[$0], P=[$1])
+        LogicalValues(tuples=[[{ 10, false }, { 100, true }]])
+    LogicalAggregate(group=[{}], EXPR$0=[MIN($0) FILTER $1])
+      LogicalProject(V=[$0], P=[$1])
+        LogicalValues(tuples=[[{ null, true }, { 200, true }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testAggregateUnionTransposeWithOneInputNonNullable">
     <Resource name="sql">
       <![CDATA[select deptno, SUM(t) from (

--- a/core/src/test/resources/sql/hep.iq
+++ b/core/src/test/resources/sql/hep.iq
@@ -103,6 +103,25 @@ EnumerableSort(sort0=[$1], dir0=[ASC])
     EnumerableCalc(expr#0..7=[{inputs}], expr#8=[CAST($t3):INTEGER], expr#9=[7698], expr#10=[=($t8, $t9)], expr#11=[CAST($t6):DECIMAL(12, 2)], expr#12=[500.00:DECIMAL(12, 2)], expr#13=[=($t11, $t12)], expr#14=[IS NOT TRUE($t13)], expr#15=[AND($t10, $t14)], MGR=[$t3], COMM=[$t6], $condition=[$t15])
       EnumerableTableScan(table=[[scott, EMP]])
 !plan
+
+# [CALCITE-7645] AggregateUnionTransposeRule must preserve aggregate FILTER when creating pushed-down aggregates
+!set hep-rules "
++AGGREGATE_UNION_TRANSPOSE"
+
+select min(v) filter (where p) as m
+from (
+  select * from (values (10, false), (100, true)) as t(v, p)
+  union all
+  select * from (values (cast(null as integer), true), (200, true)) as t(v, p)
+);
++-----+
+| M   |
++-----+
+| 100 |
++-----+
+(1 row)
+
+!ok
 !set hep-rules original
 
 # Testing with the planner-rules shows that due to cost-based selection issues,


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-7645](https://issues.apache.org/jira/browse/CALCITE-7645)
