### PR TITLE
Correct typo in Pig aggregate UDF exception message

### DIFF
--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelUdfConverter.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelUdfConverter.java
@@ -183,7 +183,7 @@ class PigRelUdfConverter {
             ((ScalarFunctionImpl) pigUdf.getFunction()).method.getDeclaringClass();
         if (Accumulator.class.isAssignableFrom(udfClass)) {
           throw new UnsupportedOperationException(
-              "Cannot find corresponding SqlAgg func for Pig aggegate " + pigUdfClassName);
+              "Cannot find corresponding SqlAgg func for Pig aggregate " + pigUdfClassName);
         }
       }
       return sqlAggFunction;


### PR DESCRIPTION

## Jira Link

Not applicable. Per the PR template, a Jira issue is not required for typos and
cosmetic changes (changes that are neither bugs nor features). This PR only
corrects a misspelled word in a user-facing exception message; there is no
functional change.

## Changes Proposed

Fixes a typo in the `UnsupportedOperationException` message thrown by
`PigRelUdfConverter.getSqlAggFuncForPigUdf`. The word "aggegate" was a
misspelling of "aggregate".

`piglet/src/main/java/org/apache/calcite/piglet/PigRelUdfConverter.java`:

```diff
-              "Cannot find corresponding SqlAgg func for Pig aggegate " + pigUdfClassName);
+              "Cannot find corresponding SqlAgg func for Pig aggregate " + pigUdfClassName);
```

This message is surfaced to the user when a Pig `Accumulator` UDF has no built-in
SQL aggregate equivalent. The corrected spelling also matches the method's own
Javadoc, which already refers to the "Pig aggregate UDF call".

No behavior changes and no new tests: the message string is not matched or parsed
anywhere in the codebase, so this is a message-only correction. Validated locally
with `./gradlew :piglet:autostyleCheck :piglet:checkstyleMain :piglet:compileJava`
and `./gradlew :core:test --tests "*.LintTest.testLintLog" --tests
"*.LintTest.testLogMatcher"`.
