### PR TITLE
Change typos in exception messages

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/TableNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/TableNamespace.java
@@ -126,7 +126,7 @@ class TableNamespace extends AbstractNamespace {
       final SqlValidatorTable validatorTable =
           requireNonNull(
             relOptTable.unwrap(SqlValidatorTable.class),
-            () -> "cant unwrap SqlValidatorTable from " + relOptTable);
+            () -> "can't unwrap SqlValidatorTable from " + relOptTable);
       return new TableNamespace(validator, validatorTable, ImmutableList.of());
     }
     return new TableNamespace(validator, table, extendedFields);

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelBuilder.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelBuilder.java
@@ -246,7 +246,7 @@ public class PigRelBuilder extends RelBuilder {
         // If both schemas are valid, they must be compatible
         throw new IllegalArgumentException(
             "Pig script schema does not match database schema for table " + names + ".\n"
-                + "\t Scrip schema: " + userSchema.getRowType().getFullTypeString() + "\n"
+                + "\t Script schema: " + userSchema.getRowType().getFullTypeString() + "\n"
                 + "\t Database schema: " + systemSchema.getRowType().getFullTypeString());
       }
       // We choose to use systemSchema if it is valid

--- a/piglet/src/main/java/org/apache/calcite/piglet/PigRelUdfConverter.java
+++ b/piglet/src/main/java/org/apache/calcite/piglet/PigRelUdfConverter.java
@@ -183,7 +183,7 @@ class PigRelUdfConverter {
             ((ScalarFunctionImpl) pigUdf.getFunction()).method.getDeclaringClass();
         if (Accumulator.class.isAssignableFrom(udfClass)) {
           throw new UnsupportedOperationException(
-              "Cannot find corresponding SqlAgg func for Pig aggegate " + pigUdfClassName);
+              "Cannot find corresponding SqlAgg func for Pig aggregate " + pigUdfClassName);
         }
       }
       return sqlAggFunction;


### PR DESCRIPTION
## Jira Link

Not required. Per the PR template and contributing guide, a Jira issue is not needed for typos and cosmetic changes. This PR only corrects user-facing/internal exception message text; there is no behavioral change.

## Changes Proposed

This PR consolidates three small typo corrections into one pull request:

- In `PigRelBuilder.scan(RelOptTable, String...)`, change `Scrip schema:` to `Script schema:` in the Pig script schema mismatch message.
- In `PigRelUdfConverter.getSqlAggFuncForPigUdf`, change `Pig aggegate` to `Pig aggregate`.
- In `TableNamespace.extend(...)`, change `cant unwrap SqlValidatorTable from` to `can't unwrap SqlValidatorTable from`.

The branch has been rebased onto the latest `origin/main`, and the changes are intentionally kept as three commits with commit messages starting with `Change`.

Validated locally with:

```
./gradlew :core:compileJava :piglet:autostyleCheck :piglet:checkstyleMain :piglet:compileJava
```

No tests were added because these are message-only typo corrections and no existing code parses or depends on these exact strings.