### PR TITLE
change typo in TableNamespace exception message (cant -> can't)

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/TableNamespace.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/TableNamespace.java
@@ -126,7 +126,7 @@ class TableNamespace extends AbstractNamespace {
       final SqlValidatorTable validatorTable =
           requireNonNull(
             relOptTable.unwrap(SqlValidatorTable.class),
-            () -> "cant unwrap SqlValidatorTable from " + relOptTable);
+            () -> "can't unwrap SqlValidatorTable from " + relOptTable);
       return new TableNamespace(validator, validatorTable, ImmutableList.of());
     }
     return new TableNamespace(validator, table, extendedFields);


### PR DESCRIPTION

## Jira Link

N/A. Per this repository's pull request template, a Jira issue is not required
for typos and cosmetic changes (changes that are neither bugs nor features).
This is a one-character typo in an internal exception message.

## Changes Proposed

`TableNamespace.extend(...)` builds a lazy message for the
`Objects.requireNonNull` guard that fires when a `RelOptTable` cannot be
unwrapped to a `SqlValidatorTable`. That message reads `cant unwrap
SqlValidatorTable from ...`; `cant` should be `can't`.

```diff
             relOptTable.unwrap(SqlValidatorTable.class),
-            () -> "cant unwrap SqlValidatorTable from " + relOptTable);
+            () -> "can't unwrap SqlValidatorTable from " + relOptTable);
```

The sibling guard a few lines below, in `getBaseRowType()`, already uses the
correct spelling (`"can't unwrap Table from "`), so this change simply makes the
two messages in the same file consistent. It is text-only: no behavior, control
flow, or overload resolution changes.

No test is added: the string is an internal null-check message on a hard-to-reach
invariant path, and Calcite does not unit-test these guard messages. `./gradlew
build` passes; `autostyleApply` reports no changes and `checkstyleMain` is clean.
