### PR TITLE
[CALCITE-6393] Byte code of SqlFunctions is invalid

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SqlFunctions.java
@@ -210,18 +210,24 @@ public class SqlFunctions {
 
   @SuppressWarnings("unused")
   private static final Function1<Object[], Enumerable<@Nullable Object[]>> ARRAY_CARTESIAN_PRODUCT =
-      lists -> {
-        final List<Enumerator<@Nullable Object>> enumerators = new ArrayList<>();
-        for (Object list : lists) {
-          enumerators.add(Linq4j.enumerator((List) list));
-        }
-        final Enumerator<List<@Nullable Object>> product = Linq4j.product(enumerators);
-        return new AbstractEnumerable<@Nullable Object[]>() {
-          @Override public Enumerator<@Nullable Object[]> enumerator() {
-            return Linq4j.transform(product, List::toArray);
-          }
-        };
-      };
+      SqlFunctions::arrayCartesianProduct;
+
+  /**
+   * WARNING: keep this logic as a static method. JDK 8 and 11 produce invalid bytecode when
+   * checkerframework annotations are used on static lambdas. See CALCITE-6393.
+   */
+  private static Enumerable<@Nullable Object[]> arrayCartesianProduct(Object[] lists) {
+    final List<Enumerator<@Nullable Object>> enumerators = new ArrayList<>();
+    for (Object list : lists) {
+      enumerators.add(Linq4j.enumerator((List) list));
+    }
+    final Enumerator<List<@Nullable Object>> product = Linq4j.product(enumerators);
+    return new AbstractEnumerable<@Nullable Object[]>() {
+      @Override public Enumerator<@Nullable Object[]> enumerator() {
+        return Linq4j.transform(product, List::toArray);
+      }
+    };
+  }
 
   /** Holds, for each thread, a map from sequence name to sequence current
    * value.


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-6393](https://issues.apache.org/jira/browse/CALCITE-6393)

## Changes Proposed
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.
-->
Use a static method (instead of a lambda) for `ARRAY_CARTESIAN_PRODUCT`. This avoids a JDK 8 and 11 bug that produces invalid bytecode regarding checkerframework annotations.
Verified using bytecode checker proposed in https://github.com/apache/calcite/pull/5090

More info: Body of the `ARRAY_CARTESIAN_PRODUCT` lambda extracted into an ordinary static method so that its `@Nullable` type annotations on doubly-nested type arguments (e.g. `List<Enumerator<@Nullable Object>>`) are attached the method's attribute table rather than to the enclosing `<clinit>`. This works around a javac bug in which type annotations declared inside a lambda body are emitted into the enclosing `<clinit>` attribute table with the lambda's own bytecode PCs and local-variable slots, producing malformed `RuntimeVisibleTypeAnnotations` entries that ASM's `ClassRemapper` rejects.