### PR TITLE
BigQuery dialect should escape backslashes in string literals

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/BigQuerySqlDialect.java
@@ -117,6 +117,16 @@ public class BigQuerySqlDialect extends SqlDialect {
         || RESERVED_KEYWORDS.contains(val.toUpperCase(Locale.ROOT));
   }
 
+  @Override public void quoteStringLiteral(StringBuilder buf,
+      @Nullable String charsetName, String val) {
+    // BigQuery treats backslash as an escape character inside string literals,
+    // so a literal backslash must be doubled before the base method escapes the
+    // enclosing quote as \'. Otherwise a value containing a backslash (e.g.
+    // "x\" or "\'; ...") terminates the literal early and the trailing text is
+    // parsed as SQL rather than data.
+    super.quoteStringLiteral(buf, charsetName, val.replace("\\", "\\\\"));
+  }
+
   @Override public boolean supportsImplicitTypeCoercion(RexCall call) {
     return super.supportsImplicitTypeCoercion(call)
             && RexUtil.isLiteral(call.getOperands().get(0), false)

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -3905,6 +3905,20 @@ class RelToSqlConverterTest {
         .withBigQuery().ok(expectedBigQuery);
   }
 
+  /** Tests that a backslash in a character literal is escaped for BigQuery,
+   * which uses backslash as the escape character. Without doubling the
+   * backslash the generated literal is terminated early. */
+  @Test void testCharLiteralWithBackslashForBigQuery() {
+    final String query = "select 'a\\b' from \"product\"";
+    final String expectedPostgresql = "SELECT 'a\\b'\n"
+        + "FROM \"foodmart\".\"product\"";
+    final String expectedBigQuery = "SELECT 'a\\\\b'\n"
+        + "FROM foodmart.product";
+    sql(query)
+        .withPostgresql().ok(expectedPostgresql)
+        .withBigQuery().ok(expectedBigQuery);
+  }
+
   @Test void testIdentifier() {
     // Note that IGNORE is reserved in BigQuery but not in standard SQL
     final String query = "select *\n"


### PR DESCRIPTION
## Jira Link

No Jira filed yet; happy to open one if preferred. This is a small escaping fix in the SQL generator.

## Changes Proposed

`BigQuerySqlDialect` declares its escaped quote as `\'`, but the base `quoteStringLiteral` only replaces the quote character, so a literal backslash in a string value reaches BigQuery unescaped. BigQuery treats backslash as an escape character inside string literals, so a pushed-down value such as `x\` or `\'; ...` closes the literal early and the trailing characters are parsed as SQL rather than data. Override `quoteStringLiteral` to double backslashes before the base method escapes the enclosing quote, so backslash-containing values round-trip as data. Added a rel2sql regression test next to `testCharLiteralForBigQuery`.
