### PR TITLE
ST_GeomFromGML should not resolve external XML entities

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
@@ -31,14 +31,19 @@ import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.io.WKTWriter;
 import org.locationtech.jts.io.geojson.GeoJsonReader;
 import org.locationtech.jts.io.geojson.GeoJsonWriter;
-import org.locationtech.jts.io.gml2.GMLReader;
+import org.locationtech.jts.io.gml2.GMLHandler;
 import org.locationtech.jts.io.gml2.GMLWriter;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.Locale;
 import java.util.regex.Pattern;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 
 import static java.lang.Integer.parseInt;
 
@@ -135,8 +140,19 @@ public class SpatialTypeUtils {
    */
   public static Geometry fromGml(String gml) {
     try {
-      GMLReader reader = new GMLReader();
-      return reader.read(gml, GEOMETRY_FACTORY);
+      // Configure the parser to reject DOCTYPE declarations and external
+      // entities so that untrusted GML cannot trigger XXE (local file
+      // disclosure or SSRF). JTS GMLReader builds a SAX parser with the
+      // JAXP defaults, which resolve external entities.
+      SAXParserFactory factory = SAXParserFactory.newInstance();
+      factory.setNamespaceAware(false);
+      factory.setValidating(false);
+      factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      SAXParser parser = factory.newSAXParser();
+      GMLHandler handler = new GMLHandler(GEOMETRY_FACTORY, null);
+      parser.parse(new InputSource(new StringReader(gml)), handler);
+      return handler.getGeometry();
     } catch (SAXException | IOException | ParserConfigurationException e) {
       throw new RuntimeException("Unable to parse GML");
     }

--- a/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
@@ -35,6 +35,7 @@ import org.locationtech.jts.io.gml2.GMLHandler;
 import org.locationtech.jts.io.gml2.GMLWriter;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -150,7 +151,7 @@ public class SpatialTypeUtils {
       factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
       factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
       SAXParser parser = factory.newSAXParser();
-      GMLHandler handler = new GMLHandler(GEOMETRY_FACTORY, null);
+      GMLHandler handler = new GMLHandler(GEOMETRY_FACTORY, new DefaultHandler());
       parser.parse(new InputSource(new StringReader(gml)), handler);
       return handler.getGeometry();
     } catch (SAXException | IOException | ParserConfigurationException e) {

--- a/core/src/test/java/org/apache/calcite/runtime/SpatialTypeUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/runtime/SpatialTypeUtilsTest.java
@@ -23,6 +23,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link org.apache.calcite.runtime.SpatialTypeUtilsTest}.
@@ -52,5 +53,23 @@ class SpatialTypeUtilsTest {
     Geometry g1 = gf.createPoint(new Coordinate(1, 2));
     g1.setSRID(1234);
     assertThat(SpatialTypeUtils.asEwkt(g1), is("srid:1234;POINT (1 2)"));
+  }
+
+  @Test void testFromGml() {
+    Geometry g = SpatialTypeUtils.fromGml("<gml:Point xmlns:gml=\"http://www.opengis.net/gml\">"
+        + "<gml:coordinates>1,2</gml:coordinates></gml:Point>");
+    assertThat(g.getCoordinate().getX(), is(1D));
+    assertThat(g.getCoordinate().getY(), is(2D));
+  }
+
+  /** Tests that GML parsing does not process DOCTYPE declarations or external
+   * entities, so a crafted document cannot read local files or open network
+   * connections (XXE). */
+  @Test void testFromGmlRejectsDoctype() {
+    String gml = "<?xml version=\"1.0\"?>\n"
+        + "<!DOCTYPE Point [ <!ENTITY xxe \"1,2\"> ]>\n"
+        + "<gml:Point xmlns:gml=\"http://www.opengis.net/gml\">"
+        + "<gml:coordinates>&xxe;</gml:coordinates></gml:Point>";
+    assertThrows(RuntimeException.class, () -> SpatialTypeUtils.fromGml(gml));
   }
 }


### PR DESCRIPTION
## Jira Link

Not filed yet; glad to open a CALCITE issue for tracking if you prefer one.

## Changes Proposed

`ST_GeomFromGML` hands the GML text straight to `SpatialTypeUtils.fromGml`, which parses it with JTS `GMLReader`. That reader builds a SAX parser from the JAXP defaults, so DOCTYPE declarations and external entities are resolved. The GML argument is ordinary untrusted data (a literal, parameter, or row value), so a document like `<!DOCTYPE p [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]>` referenced from `<gml:coordinates>` reads a local file, and an external-DTD reference makes the parser open an outbound connection, giving both file disclosure and SSRF (XXE). The XML functions in `XmlFunctions` were already hardened against this, but the spatial path slipped through because JTS constructs its own parser instead of reusing that configuration. I noticed it while checking which readers under `runtime` touch untrusted XML. The fix builds the SAX parser inside `fromGml` with `FEATURE_SECURE_PROCESSING` and `disallow-doctype-decl` and drives JTS `GMLHandler` directly, matching the existing hardening; valid GML parses exactly as before, and the added test confirms a document carrying a DOCTYPE is rejected.

Repro (with `fun=spatial`):

```sql
SELECT ST_GeomFromGML(
  '<?xml version="1.0"?>
   <!DOCTYPE Point [ <!ENTITY xxe SYSTEM "file:///etc/passwd"> ]>
   <gml:Point xmlns:gml="http://www.opengis.net/gml"><gml:coordinates>&xxe;</gml:coordinates></gml:Point>');
```

`./gradlew :core:test` (SpatialTypeUtilsTest, CoreQuidemTest), checkstyle, autostyle and forbiddenApis pass locally.