### PR TITLE
[CALCITE-7656] Result type inferred for VAR_SAMP is incorrect

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/ReturnTypes.java
@@ -1581,8 +1581,10 @@ public abstract class ReturnTypes {
     final RelDataType relDataType =
         typeFactory.getTypeSystem().deriveAvgAggType(typeFactory,
             opBinding.getOperandType(0));
+    final SqlKind kind = opBinding.getOperator().kind;
     if (opBinding.hasEmptyGroup() || opBinding.hasFilter()
-        || opBinding.getOperator().kind == SqlKind.STDDEV_SAMP) {
+        || kind == SqlKind.STDDEV_SAMP
+        || kind == SqlKind.VAR_SAMP) {
       return typeFactory.createTypeWithNullability(relDataType, true);
     } else {
       return relDataType;
@@ -1594,7 +1596,8 @@ public abstract class ReturnTypes {
     final RelDataType relDataType =
         typeFactory.getTypeSystem().deriveCovarType(typeFactory,
             opBinding.getOperandType(0), opBinding.getOperandType(1));
-    if (opBinding.hasEmptyGroup() || opBinding.hasFilter()) {
+    if (opBinding.hasEmptyGroup() || opBinding.hasFilter()
+        || opBinding.getOperator().kind == SqlKind.COVAR_SAMP) {
       return typeFactory.createTypeWithNullability(relDataType, true);
     } else {
       return relDataType;

--- a/core/src/test/resources/org/apache/calcite/test/AggregateReduceFunctionsOnGroupKeysRuleTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/AggregateReduceFunctionsOnGroupKeysRuleTest.xml
@@ -338,7 +338,7 @@ LogicalProject(SAL=[$0], SD=[$2], SDP=[$3], VP=[$4], VS=[$5])
     <Resource name="planAfter">
       <![CDATA[
 LogicalProject(SAL=[$0], SD=[$2], SDP=[$3], VP=[$4], VS=[$5])
-  LogicalProject(SAL=[$0], DEPTNO=[$1], SD=[CAST(0):INTEGER], SDP=[0], VP=[0], VS=[0])
+  LogicalProject(SAL=[$0], DEPTNO=[$1], SD=[CAST(0):INTEGER], SDP=[0], VP=[0], VS=[CAST(0):INTEGER])
     LogicalAggregate(group=[{0, 1}])
       LogicalProject(SAL=[$5], DEPTNO=[$7])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -472,7 +472,7 @@ LogicalProject(SAL=[$0], VS=[$2])
     <Resource name="planAfter">
       <![CDATA[
 LogicalProject(SAL=[$0], VS=[$2])
-  LogicalProject(SAL=[$0], DEPTNO=[$1], VS=[0])
+  LogicalProject(SAL=[$0], DEPTNO=[$1], VS=[CAST(0):INTEGER])
     LogicalAggregate(group=[{0, 1}])
       LogicalProject(SAL=[$5], DEPTNO=[$7])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])
@@ -569,7 +569,7 @@ LogicalProject(SAL=[$0], VS=[$2])
     <Resource name="planAfter">
       <![CDATA[
 LogicalProject(SAL=[$0], VS=[$2])
-  LogicalProject(SAL=[$0], DEPTNO=[$1], VS=[0])
+  LogicalProject(SAL=[$0], DEPTNO=[$1], VS=[CAST(0):INTEGER])
     LogicalAggregate(group=[{0, 1}])
       LogicalProject(SAL=[$5], DEPTNO=[$7], $f2=[*($5, $7)])
         LogicalTableScan(table=[[CATALOG, SALES, EMP]])

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -2055,7 +2055,7 @@ LogicalAggregate(group=[{0}], EXPR$1=[STDDEV_POP($1)], EXPR$2=[AVG($1)], EXPR$3=
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalProject(NAME=[$0], EXPR$1=[CAST(POWER(/(-($1, /(*($2, $2), $3)), $3), 0.5:DECIMAL(2, 1))):INTEGER NOT NULL], EXPR$2=[CAST(/($2, $3)):INTEGER NOT NULL], EXPR$3=[CAST(POWER(/(-($1, /(*($2, $2), $3)), CASE(=($3, 1), null:BIGINT, -($3, 1))), 0.5:DECIMAL(2, 1))):INTEGER], EXPR$4=[CAST(/(-($1, /(*($2, $2), $3)), $3)):INTEGER NOT NULL], EXPR$5=[CAST(/(-($1, /(*($2, $2), $3)), CASE(=($3, 1), null:BIGINT, -($3, 1)))):INTEGER NOT NULL])
+LogicalProject(NAME=[$0], EXPR$1=[CAST(POWER(/(-($1, /(*($2, $2), $3)), $3), 0.5:DECIMAL(2, 1))):INTEGER NOT NULL], EXPR$2=[CAST(/($2, $3)):INTEGER NOT NULL], EXPR$3=[CAST(POWER(/(-($1, /(*($2, $2), $3)), CASE(=($3, 1), null:BIGINT, -($3, 1))), 0.5:DECIMAL(2, 1))):INTEGER], EXPR$4=[CAST(/(-($1, /(*($2, $2), $3)), $3)):INTEGER NOT NULL], EXPR$5=[CAST(/(-($1, /(*($2, $2), $3)), CASE(=($3, 1), null:BIGINT, -($3, 1)))):INTEGER])
   LogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], agg#1=[$SUM0($1)], agg#2=[COUNT()])
     LogicalProject(NAME=[$0], DEPTNO=[$1], $f2=[*($1, $1)])
       LogicalProject(NAME=[$1], DEPTNO=[$0])
@@ -16331,7 +16331,7 @@ LogicalAggregate(group=[{0}], EXPR$1=[STDDEV_POP($1)], EXPR$2=[AVG($1)], EXPR$3=
     </Resource>
     <Resource name="planAfter">
       <![CDATA[
-LogicalProject(NAME=[$0], EXPR$1=[CAST(POWER(/(-($1, /(*($2, $2), $3)), $3), 0.5:DECIMAL(2, 1))):INTEGER NOT NULL], EXPR$2=[CAST(/($2, $3)):INTEGER NOT NULL], EXPR$3=[CAST(POWER(/(-($1, /(*($2, $2), $3)), CASE(=($3, 1), null:BIGINT, -($3, 1))), 0.5:DECIMAL(2, 1))):INTEGER], EXPR$4=[CAST(/(-($1, /(*($2, $2), $3)), $3)):INTEGER NOT NULL], EXPR$5=[CAST(/(-($1, /(*($2, $2), $3)), CASE(=($3, 1), null:BIGINT, -($3, 1)))):INTEGER NOT NULL])
+LogicalProject(NAME=[$0], EXPR$1=[CAST(POWER(/(-($1, /(*($2, $2), $3)), $3), 0.5:DECIMAL(2, 1))):INTEGER NOT NULL], EXPR$2=[CAST(/($2, $3)):INTEGER NOT NULL], EXPR$3=[CAST(POWER(/(-($1, /(*($2, $2), $3)), CASE(=($3, 1), null:BIGINT, -($3, 1))), 0.5:DECIMAL(2, 1))):INTEGER], EXPR$4=[CAST(/(-($1, /(*($2, $2), $3)), $3)):INTEGER NOT NULL], EXPR$5=[CAST(/(-($1, /(*($2, $2), $3)), CASE(=($3, 1), null:BIGINT, -($3, 1)))):INTEGER])
   LogicalAggregate(group=[{0}], agg#0=[$SUM0($2)], agg#1=[$SUM0($1)], agg#2=[COUNT()])
     LogicalProject(NAME=[$0], DEPTNO=[$1], $f2=[*($1, $1)])
       LogicalProject(NAME=[$1], DEPTNO=[$0])

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -16083,12 +16083,9 @@ public class SqlOperatorTest {
         "DECIMAL(19, 9)");
     f.checkType("covar_samp(CAST(NULL AS INTEGER),CAST(NULL AS INTEGER))",
         "INTEGER");
-    f.checkAggType("covar_samp(1.5, 2.5)", "DECIMAL(2, 1) NOT NULL");
-    if (!f.brokenTestsEnabled()) {
-      return;
-    }
+    f.checkAggType("covar_samp(1.5, 2.5)", "DECIMAL(2, 1)");
     // with zero values
-    f.checkAgg("covar_samp(x)", new String[]{}, isNullValue());
+    f.checkAgg("covar_samp(x, x)", new String[]{}, isNullValue());
   }
 
   @Test void testRegrSxxFunc() {
@@ -16264,7 +16261,7 @@ public class SqlOperatorTest {
             false);
     f.checkType("var_samp(cast(null as varchar(2)))", "DECIMAL(19, 9)");
     f.checkType("var_samp(CAST(NULL AS INTEGER))", "INTEGER");
-    f.checkAggType("var_samp(DISTINCT 1.5)", "DECIMAL(2, 1) NOT NULL");
+    f.checkAggType("var_samp(DISTINCT 1.5)", "DECIMAL(2, 1)");
     final String[] values = {"0", "CAST(null AS FLOAT)", "3", "3"};
     if (!f.brokenTestsEnabled()) {
       return;
@@ -16292,7 +16289,7 @@ public class SqlOperatorTest {
             false);
     f.checkType("variance(cast(null as varchar(2)))", "DECIMAL(19, 9)");
     f.checkType("variance(CAST(NULL AS INTEGER))", "INTEGER");
-    f.checkAggType("variance(DISTINCT 1.5)", "DECIMAL(2, 1) NOT NULL");
+    f.checkAggType("variance(DISTINCT 1.5)", "DECIMAL(2, 1)");
 
     final String[] values2 = {"cast(64.34 as double)", "64.34", "64.34"};
     f.checkAgg("variance(x)", values2, isExactly(0));


### PR DESCRIPTION
## Jira Link

[CALCITE-7656](https://issues.apache.org/jira/browse/CALCITE-7656)

## Changes Proposed

The result of these statistical functions can be nullable even if no input is nullable.
