### PR TITLE
Test case for [CALCITE-5216] Cannot parse parenthesized nested WITH clause

### DIFF
--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -937,6 +937,18 @@ where sal + 100 not in (
 !ok
 !}
 
+# [CALCITE-5216] Cannot parse parenthesized nested WITH clause
+# This sql program was validated in PostgreSQL
+with a as (with b as (select 1)(select 1)) select * from a;
++--------+
+| EXPR$0 |
++--------+
+|      1 |
++--------+
+(1 row)
+
+!ok
+
 # [CALCITE-356] AssertionError while translating query with WITH and correlated sub-query
 !if (use_old_decorr) {
 with t (a, b) as (select * from (values (1, 2)))

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -2859,6 +2859,16 @@ public class SqlParserTest {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-5216">[CALCITE-5216]
+   * Cannot parse parenthesized nested WITH clause</a>. */
+  @Test void testNestedWithParenthesized() {
+    final String sql = "with a as (with b as (select 1)(select 1)) select * from a";
+    final String expected = "WITH `A` AS (WITH `B` AS (SELECT 1) SELECT 1) SELECT *\n"
+        + "FROM `A`";
+    sql(sql).ok(expected);
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5252">[CALCITE-5252]
    * JDBC adapter sometimes miss parentheses around SELECT in WITH_ITEM body</a>. */
   @Test void testWithAsUnion() {


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/CALCITE-5216

It seems the current Jira issue has been fixed; I only added relevant tests, and they ran successfully.