### PR TITLE
[CALCITE-7660] `SqlSetSemanticsTableOperator` might produce invalid SQL while unparse

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -1744,7 +1744,8 @@ SqlNode PartitionedQueryOrQueryOrExpr(ExprContext exprContext) :
     SqlNode e;
 }
 {
-    e = OrderedQueryOrExpr(exprContext)
+    // QueryOrExpr, not OrderedQueryOrExpr: ORDER BY is handled by PartitionedByAndOrderBy below.
+    e = QueryOrExpr(exprContext)
     e = PartitionedByAndOrderBy(e)
 
     { return e; }

--- a/core/src/main/java/org/apache/calcite/sql/SqlSetSemanticsTableOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlSetSemanticsTableOperator.java
@@ -67,17 +67,20 @@ public class SqlSetSemanticsTableOperator extends SqlInternalOperator {
     SqlNodeList partitionList = call.operand(1);
     if (!partitionList.isEmpty()) {
       writer.sep("PARTITION BY");
-      final SqlWriter.Frame partitionFrame = writer.startList("", "");
+      final SqlWriter.Frame partitionFrame = partitionList.size() == 1
+          ? writer.startList("", "")
+          : writer.startList("(", ")");
       partitionList.unparse(writer, 0, 0);
       writer.endList(partitionFrame);
     }
     SqlNodeList orderList = call.operand(2);
     if (!orderList.isEmpty()) {
       writer.sep("ORDER BY");
-      writer.list(
-          SqlWriter.FrameTypeEnum.ORDER_BY_LIST,
-          SqlWriter.COMMA,
-          orderList);
+      final SqlWriter.Frame orderFrame = orderList.size() == 1
+          ? writer.startList("", "")
+          : writer.startList("(", ")");
+      orderList.unparse(writer, 0, 0);
+      writer.endList(orderFrame);
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1979,12 +1979,28 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .ok();
     // test multiple partition keys for input table with set semantic
     sql("select * from table(topn(table orders partition by (orderId, productid), 3))")
+        .rewritesTo("SELECT *\n"
+            + "FROM TABLE(TOPN((SELECT *\n"
+            + "FROM `ORDERS`) PARTITION BY (`ORDERID`, `PRODUCTID`), 3))")
+        .ok();
+    sql("select * from table(topn(table orders partition by (orderId), 3))")
+        .rewritesTo("SELECT *\n"
+            + "FROM TABLE(TOPN((SELECT *\n"
+            + "FROM `ORDERS`) PARTITION BY `ORDERID`, 3))")
         .ok();
     // test one order key for input table with set semantic
     sql("select * from table(topn(table orders order by orderId, 3))")
         .ok();
+    sql("select * from table(topn(table orders order by (orderId), 3))")
+        .rewritesTo("SELECT *\n"
+            + "FROM TABLE(TOPN((SELECT *\n"
+            + "FROM `ORDERS`) ORDER BY `ORDERID`, 3))")
+        .ok();
     // test multiple order keys for input table with set semantic
     sql("select * from table(topn(table orders order by (orderId, productid), 3))")
+        .rewritesTo("SELECT *\n"
+            + "FROM TABLE(TOPN((SELECT *\n"
+            + "FROM `ORDERS`) ORDER BY (`ORDERID`, `PRODUCTID`), 3))")
         .ok();
     // test complex order-by clause for input table with set semantic
     sql("select * from table(topn(table orders order by (orderId desc, productid asc), 3))")

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -5007,8 +5007,9 @@ public class SqlParserTest {
     final String sql =
         "select * from table(topn(table orders partition by (orderId, productid), 3))";
     final String expected = "SELECT *\n"
-        + "FROM TABLE(`TOPN`((TABLE `ORDERS`) PARTITION BY `ORDERID`, `PRODUCTID`, 3))";
+        + "FROM TABLE(`TOPN`((TABLE `ORDERS`) PARTITION BY (`ORDERID`, `PRODUCTID`), 3))";
     sql(sql).ok(expected);
+    sql(expected).withConfig(c -> c.withQuoting(Quoting.BACK_TICK)).same();
   }
 
   @Test void testTableFunctionWithOrderKey() {
@@ -5025,8 +5026,9 @@ public class SqlParserTest {
     final String sql =
         "select * from table(topn(table orders order by (orderId, productid), 3))";
     final String expected = "SELECT *\n"
-        + "FROM TABLE(`TOPN`((TABLE `ORDERS`) ORDER BY `ORDERID`, `PRODUCTID`, 3))";
+        + "FROM TABLE(`TOPN`((TABLE `ORDERS`) ORDER BY (`ORDERID`, `PRODUCTID`), 3))";
     sql(sql).ok(expected);
+    sql(expected).withConfig(c -> c.withQuoting(Quoting.BACK_TICK)).same();
   }
 
   @Test void testTableFunctionWithComplexOrderBy() {
@@ -5034,8 +5036,9 @@ public class SqlParserTest {
     final String sql =
         "select * from table(topn(table orders order by (orderId desc, productid asc), 3))";
     final String expected = "SELECT *\n"
-        + "FROM TABLE(`TOPN`((TABLE `ORDERS`) ORDER BY `ORDERID` DESC, `PRODUCTID`, 3))";
+        + "FROM TABLE(`TOPN`((TABLE `ORDERS`) ORDER BY (`ORDERID` DESC, `PRODUCTID`), 3))";
     sql(sql).ok(expected);
+    sql(expected).withConfig(c -> c.withQuoting(Quoting.BACK_TICK)).same();
   }
 
   @Test void testTableFunctionWithPartitionKeyAndOrderKey() {


### PR DESCRIPTION

## Jira Link

[CALCITE-7660](https://issues.apache.org/jira/browse/CALCITE-7660)

## Changes Proposed
The PR fixes unparse for `PARTITION BY`, `ORDER BY` in `TABLE` for the case of several fields
