### PR TITLE
[CALCITE-7668] MongoDB adapter should escape embedded quotes in field references

### DIFF
--- a/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoRules.java
+++ b/mongodb/src/main/java/org/apache/calcite/adapter/mongodb/MongoRules.java
@@ -110,7 +110,9 @@ public class MongoRules {
   }
 
   static String quote(String s) {
-    return "'" + s + "'"; // TODO: handle embedded quotes
+    // Escape backslash and the single-quote delimiter so that s cannot break
+    // out of the quoted token when the string is parsed by BsonDocument.parse.
+    return "'" + s.replace("\\", "\\\\").replace("'", "\\'") + "'";
   }
 
   private static boolean needsQuote(String s) {
@@ -181,7 +183,7 @@ public class MongoRules {
     @Override public String visitCall(RexCall call) {
       String name = isItem(call);
       if (name != null) {
-        return "'$" + name + "'";
+        return quote("$" + name);
       }
       final List<String> strings = visitList(call.operands);
       if (call.getKind() == SqlKind.CAST) {

--- a/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
+++ b/mongodb/src/test/java/org/apache/calcite/adapter/mongodb/MongoAdapterTest.java
@@ -86,6 +86,13 @@ public class MongoAdapterTest implements SchemaFactory {
   /** Number of records in local file. */
   protected static final int ZIPS_SIZE = 149;
 
+  /** Field of the "datatypes" collection whose name contains a single quote
+   * and characters that would be pipeline syntax if it were not escaped. */
+  private static final String QUOTED_FIELD = "x', injected: {$literal: 1}, y: 'z";
+
+  /** Field of the "datatypes" collection whose name ends with a backslash. */
+  private static final String BACKSLASH_FIELD = "a\\";
+
   @RegisterExtension
   public static final MongoDatabasePolicy POLICY = MongoDatabasePolicy.create();
 
@@ -119,6 +126,8 @@ public class MongoAdapterTest implements SchemaFactory {
     doc.put("ownerId", new BsonString("531e7789e4b0853ddb861313"));
     doc.put("arr", new BsonArray(Arrays.asList(new BsonString("a"), new BsonString("b"))));
     doc.put("binaryData", new BsonBinary("binaryData".getBytes(StandardCharsets.UTF_8)));
+    doc.put(QUOTED_FIELD, new BsonString("quoted"));
+    doc.put(BACKSLASH_FIELD, new BsonString("backslash"));
     datatypes.insertOne(doc);
 
     schema = new MongoSchema(database);
@@ -741,6 +750,30 @@ public class MongoAdapterTest implements SchemaFactory {
     assertModel(MODEL)
         .query("select cast(_MAP['arr'] as VARCHAR ARRAY) from \"mongo_raw\".\"datatypes\"")
         .returnsUnordered("EXPR$0=[a, b]");
+  }
+
+  /** A field name that contains a single quote or a backslash must not be able
+   * to break out of the quoted token in the generated pipeline and add stage
+   * fields of its own.
+   *
+   * <p>The expected values were validated against a real MongoDB instance:
+   * without the escaping the first query parses as
+   * {@code {$project: {C: '$x', injected: {$literal: 1}, y: 'z'}}} and the
+   * injected field breaks the pipeline, so the query fails. */
+  @Test void testItemKeyWithEmbeddedQuote() {
+    assertModel(MODEL)
+        .query("select cast(_MAP['x'', injected: {$literal: 1}, y: ''z'] as varchar) as c\n"
+            + "from \"mongo_raw\".\"datatypes\"")
+        .returnsUnordered("C=quoted")
+        .queryContains(
+            mongoChecker("{$project: {C: '$x\\', injected: {$literal: 1}, y: \\'z'}}"));
+
+    assertModel(MODEL)
+        .query("select cast(_MAP['a\\'] as varchar) as c\n"
+            + "from \"mongo_raw\".\"datatypes\"")
+        .returnsUnordered("C=backslash")
+        .queryContains(
+            mongoChecker("{$project: {C: '$a\\\\'}}"));
   }
 
   /** Test case for


### PR DESCRIPTION
## Changes Proposed

**MongoDB pipeline injection through unescaped quotes in pushed-down field references**

The Mongo adapter renders `$project`/`$group` stages as strings that are later parsed with `BsonDocument.parse`. `MongoRules.quote` wrapped a value in single quotes but left embedded single quotes and backslashes untouched (the old `// TODO: handle embedded quotes`), and the `ITEM` path that handles `_MAP['key']` built `'$key'` the same way. Since the item key and field names come straight from the SQL statement, a value carrying a single quote closes the quoted token early and the rest is parsed as further pipeline syntax.

Reproduction: a projection such as `SELECT _MAP['x'', evil: {$literal: 1}, y: ''z'] FROM mongo` generates `{$project: {..., evil: {$literal: 1}, ...}}`, so an extra stage field lands in the pipeline sent to MongoDB. After the fix the key stays a single string.

The escaping lives in `quote` because that is the one place every field reference passes through; the item-key branch now routes through it, and the aggregate paths already call it. Added a unit test that fails on the old code.
