### PR TITLE
[CALCITE-7663] RelToSqlConverter generates ambiguous column reference…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -296,6 +296,18 @@ public abstract class SqlImplementor {
     return SqlStdOperatorTable.AS.createCall(POS, operandList);
   }
 
+  /** Wraps a column reference in an {@code AS} alias when its intrinsic name
+   * differs from {@code name}, so that the column is emitted with
+   * {@code name}. */
+  private SqlNode renameAs(SqlNode fieldNode, String name) {
+    final String currentName = fieldNode instanceof SqlIdentifier
+        ? Util.last(((SqlIdentifier) fieldNode).names)
+        : null;
+    return name.equals(currentName)
+        ? fieldNode
+        : as(fieldNode, name);
+  }
+
   /** Returns whether a list of expressions projects all fields, in order,
    * from the input, with the same names. */
   public static boolean isStar(List<RexNode> exps, RelDataType inputRowType,
@@ -2029,9 +2041,17 @@ public abstract class SqlImplementor {
           newContext = aliasContext(aliases, qualified);
         }
         if (!dialect.supportGenerateSelectStar(rel.getInput(0))) {
+          // Rename each expanded column to its (unique) row-type field name.
+          // Otherwise a sub-query that wraps a join with duplicate field names
+          // (e.g. two columns named DEPTNO) would expose two identically named
+          // columns, which is ambiguous when referenced from an outer query.
+          final List<String> fieldNames = rel.getRowType().getFieldNames();
           final List<SqlNode> expandedSelectList = new ArrayList<>();
           for (int i = 0; i < newContext.fieldCount; i++) {
-            expandedSelectList.add(newContext.field(i));
+            final SqlNode field = newContext.field(i);
+            expandedSelectList.add(i < fieldNames.size()
+                ? renameAs(field, fieldNames.get(i))
+                : field);
           }
           select.setSelectList(new SqlNodeList(expandedSelectList, POS));
         }
@@ -2392,9 +2412,17 @@ public abstract class SqlImplementor {
         boolean qualified =
             !dialect.hasImplicitTableAlias() || aliases.size() > 1;
         final Context ctx = aliasContext(aliases, qualified);
+        // Rename each expanded column to its (unique) row-type field name.
+        // Otherwise a sub-query that wraps a join with duplicate field names
+        // (e.g. two columns named DEPTNO) would expose two identically named
+        // columns, which is ambiguous when referenced from an outer query.
+        final List<String> fieldNames = expectedRel.getRowType().getFieldNames();
         final List<SqlNode> expandedList = new ArrayList<>();
         for (int i = 0; i < ctx.fieldCount; i++) {
-          expandedList.add(ctx.field(i));
+          final SqlNode field = ctx.field(i);
+          expandedList.add(i < fieldNames.size()
+              ? renameAs(field, fieldNames.get(i))
+              : field);
         }
         return new SqlSelect(select.getParserPosition(),
             (SqlNodeList) select.getOperandList().get(0),

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -9669,16 +9669,57 @@ class RelToSqlConverterTest {
             b.equals(b.field(2, 0, "DEPTNO"),
                 b.field(2, 1, "DEPTNO")))
         .build();
+    // The join has two columns named DEPTNO; the second is aliased to its
+    // unique row-type field name (DEPTNO0) so the result never exposes two
+    // identically named columns (CALCITE-7663).
     final String expected = "SELECT"
         + " \"EMP\".\"EMPNO\", \"EMP\".\"ENAME\", \"EMP\".\"JOB\","
         + " \"EMP\".\"MGR\", \"EMP\".\"HIREDATE\", \"EMP\".\"SAL\","
         + " \"EMP\".\"COMM\", \"EMP\".\"DEPTNO\","
-        + " \"DEPT\".\"DEPTNO\","
+        + " \"DEPT\".\"DEPTNO\" AS \"DEPTNO0\","
         + " \"DEPT\".\"DNAME\", \"DEPT\".\"LOC\"\n"
         + "FROM \"scott\".\"EMP\"\n"
         + "INNER JOIN \"scott\".\"DEPT\""
         + " ON \"EMP\".\"DEPTNO\" = \"DEPT\".\"DEPTNO\"";
     relFn(relFn).dialect(NO_STAR_DIALECT).ok(expected);
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7663">[CALCITE-7663]</a>.
+   * A join with duplicate field names (two DEPTNO) wrapped by a FETCH becomes a
+   * sub-query; when it is joined again, the sub-query must not expose two
+   * columns with the same name, otherwise the outer references to them are
+   * ambiguous (e.g. PostgreSQL: {@code column reference "deptno" is ambiguous}).
+   * Each expanded column is aliased to its unique row-type field name. */
+  @Test void testNoSelectStarJoinWithDuplicateNamesAndFetchIsNotAmbiguous() {
+    final Function<RelBuilder, RelNode> relFn = b -> b
+        .scan("EMP")
+        .scan("DEPT")
+        .join(JoinRelType.INNER,
+            b.equals(b.field(2, 0, "DEPTNO"), b.field(2, 1, "DEPTNO")))
+        .limit(0, 10)
+        .scan("DEPT")
+        .join(JoinRelType.INNER,
+            b.equals(b.field(2, 0, "EMPNO"), b.field(2, 1, "DEPTNO")))
+        .limit(0, 5)
+        .build();
+    final String expected = "SELECT \"t\".\"EMPNO\", \"t\".\"ENAME\","
+        + " \"t\".\"JOB\", \"t\".\"MGR\", \"t\".\"HIREDATE\", \"t\".\"SAL\","
+        + " \"t\".\"COMM\", \"t\".\"DEPTNO\", \"t\".\"DEPTNO0\","
+        + " \"t\".\"DNAME\", \"t\".\"LOC\","
+        + " \"DEPT0\".\"DEPTNO\" AS \"DEPTNO1\","
+        + " \"DEPT0\".\"DNAME\" AS \"DNAME0\", \"DEPT0\".\"LOC\" AS \"LOC0\"\n"
+        + "FROM (SELECT \"EMP\".\"EMPNO\", \"EMP\".\"ENAME\", \"EMP\".\"JOB\","
+        + " \"EMP\".\"MGR\", \"EMP\".\"HIREDATE\", \"EMP\".\"SAL\","
+        + " \"EMP\".\"COMM\", \"EMP\".\"DEPTNO\","
+        + " \"DEPT\".\"DEPTNO\" AS \"DEPTNO0\", \"DEPT\".\"DNAME\", \"DEPT\".\"LOC\"\n"
+        + "FROM \"scott\".\"EMP\"\n"
+        + "INNER JOIN \"scott\".\"DEPT\" ON \"EMP\".\"DEPTNO\" = \"DEPT\".\"DEPTNO\"\n"
+        + "FETCH NEXT 10 ROWS ONLY) AS \"t\"\n"
+        + "INNER JOIN \"scott\".\"DEPT\" AS \"DEPT0\""
+        + " ON \"t\".\"EMPNO\" = \"DEPT0\".\"DEPTNO\"\n"
+        + "FETCH NEXT 5 ROWS ONLY";
+    relFn(relFn).withPostgresql().ok(expected);
   }
 
   /** Test case for


### PR DESCRIPTION
Fixes [CALCITE-7663](https://issues.apache.org/jira/browse/CALCITE-7663).

### Problem

When `RelToSqlConverter` converts a `RelNode` for a dialect whose
`SqlDialect.supportGenerateSelectStar()` returns `false` for a join with
duplicate field names (e.g. `PostgresqlSqlDialect`), the `SELECT *` is expanded
into explicit column references, but the expanded columns are **not** aliased to
their (unique) row-type field names. When such a projection wraps a join that
has two columns with the same name (e.g. two `DEPTNO` columns), the resulting
sub-query exposes two identically named columns, and referencing that sub-query
from an outer query is ambiguous. On PostgreSQL this fails at execution with
`ERROR: column reference "..." is ambiguous`.

This only manifests through the programmatic path (`RelBuilder` / a `RelNode`
converted directly), because the parser + validator path uniquifies output
names before conversion.

### Root cause

The two `SELECT *` expansion blocks in `SqlImplementor`
(`Result#builder(...)` and `Result#maybeExpandStar(...)`) build the select list
from `Context.field(i)`, which returns the physical column reference. Its
intrinsic name can collide with another column even though the `RelNode` row
type already holds unique field names (`DEPTNO`, `DEPTNO0`). The expansion never
carried those unique names into the SQL as aliases.

### Fix

When expanding `SELECT *`, alias each column to its unique row-type field name
whenever the column's intrinsic name differs from it. This mirrors what a
`Project` node already does and matches the SQL produced through the validator
path.

### Tests

- Added `testNoSelectStarJoinWithDuplicateNamesAndFetchIsNotAmbiguous` in
  `RelToSqlConverterTest`, reproducing a join with duplicate field names wrapped
  by a FETCH and joined again.
- Updated `testNoSelectStarWithJoin` to reflect the disambiguating alias.
- `RelToSqlConverterTest`, `JdbcAdapterTest`, `autostyleCheck`, `checkstyle` all pass.
