### PR TITLE
[CALCITE-7557] Linq4j.ListEnumerable.take(int) / skip(int) diverge from EnumerableDefaults on negative counts

### DIFF
--- a/linq4j/src/main/java/org/apache/calcite/linq4j/Linq4j.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/Linq4j.java
@@ -587,10 +587,14 @@ public abstract class Linq4j {
 
     @Override public Enumerable<T> skip(int count) {
       final List<T> list = toList();
-      if (count >= list.size()) {
+      // Clamp to zero, as the BigDecimal overload does, so that a negative
+      // count skips nothing and matches EnumerableDefaults.skip rather than
+      // throwing from List.subList.
+      final int rows = Math.max(count, 0);
+      if (rows >= list.size()) {
         return Linq4j.emptyEnumerable();
       }
-      return new ListEnumerable<>(list.subList(count, list.size()));
+      return new ListEnumerable<>(list.subList(rows, list.size()));
     }
 
     @Override public Enumerable<T> skip(BigDecimal count) {
@@ -605,10 +609,14 @@ public abstract class Linq4j {
 
     @Override public Enumerable<T> take(int count) {
       final List<T> list = toList();
-      if (count >= list.size()) {
+      // Clamp to zero, as the BigDecimal overload does, so that a negative
+      // count yields an empty enumerable and matches EnumerableDefaults.take
+      // rather than throwing from List.subList.
+      final int rows = Math.max(count, 0);
+      if (rows >= list.size()) {
         return this;
       }
-      return new ListEnumerable<>(list.subList(0, count));
+      return new ListEnumerable<>(list.subList(0, rows));
     }
 
     @Override public Enumerable<T> take(BigDecimal count) {

--- a/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
+++ b/linq4j/src/test/java/org/apache/calcite/linq4j/test/Linq4jTest.java
@@ -2238,4 +2238,20 @@ public class Linq4jTest {
       new Department("HR", 20, ImmutableList.of()),
       new Department("Marketing", 30, ImmutableList.of(emps[1])),
   };
+
+  @Test void testTakeListEnumerableNegativeSize() {
+    final List<Integer> values = Arrays.asList(1, 2, 3);
+
+    assertThat(EnumerableDefaults.take(Linq4j.asEnumerable(values), -1).toList(),
+        is(empty()));
+    assertThat(Linq4j.asEnumerable(values).take(-1).toList(), is(empty()));
+  }
+
+  @Test void testSkipListEnumerableNegativeSize() {
+    final List<Integer> values = Arrays.asList(1, 2, 3);
+
+    assertThat(EnumerableDefaults.skip(Linq4j.asEnumerable(values), -1).toList(),
+        is(values));
+    assertThat(Linq4j.asEnumerable(values).skip(-1).toList(), is(values));
+  }
 }


### PR DESCRIPTION
`Linq4j.asEnumerable(list)` returns a `ListEnumerable`, whose list-specialized `take(int)` and `skip(int)` pass the count straight to `List.subList`. A negative count therefore throws, while the generic `EnumerableDefaults` path returns an empty enumerable (`take`) or the original sequence (`skip`):

```
take(-1): java.lang.IllegalArgumentException: fromIndex(0) > toIndex(-1)
skip(-1): java.lang.IndexOutOfBoundsException: fromIndex = -1
```

Since `ListEnumerable` is selected purely as an optimization for `List` inputs, it should be semantically equivalent to the generic path. This follows the direction agreed in the JIRA discussion: match the existing `EnumerableDefaults`/LINQ behaviour rather than adopt a fail-fast contract (which would be a broader change across `EnumerableDefaults`/`QueryableDefaults`).

### Fix

Clamp the count to zero in both methods. Notably, the adjacent `take(BigDecimal)`/`skip(BigDecimal)` overloads — added in CALCITE-7624, merged after that discussion — **already** clamp via `count.max(BigDecimal.ZERO)`. So the `int` overloads were the only ones in the class not clamping; this change makes them consistent with their own siblings.

`Math.max(count, 0)` is used rather than negating the count, so that `Integer.MIN_VALUE` cannot overflow.

### Tests

Adds the two reproducers from the JIRA case. Both assert that the generic and list-specialized paths agree.

Verification against `main`:

- Both new tests **fail before** the fix (`IllegalArgumentException` / `IndexOutOfBoundsException`) and pass after. In each test the first assertion — the generic `EnumerableDefaults` path — already passed before the fix, confirming this is a genuine divergence between the two paths rather than a bug in both.
- Full `./gradlew build` is green: **21599 tests, 0 failures, 0 errors** across all modules.
- `:linq4j:style` (checkstyle + autostyle) passes.

I also checked two edge cases beyond the ticket, which are not in the committed tests:

| input | `ListEnumerable` | `EnumerableDefaults` |
| --- | --- | --- |
| `take(Integer.MIN_VALUE)` | `[]` | `[]` |
| `skip(Integer.MIN_VALUE)` | `[1, 2, 3]` | `[1, 2, 3]` |
| `take(0)` / `skip(0)` | unchanged | unchanged |

`take(count >= size)` still returns `this`, preserving the existing identity optimization.
