### PR TITLE
[CALCITE-7487] ProjectJoinTransposeRule throws ArrayIndexOutOfBoundsException in PushProjector when a Join input has a zero-column row type

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/PushProjector.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PushProjector.java
@@ -457,13 +457,22 @@ public class PushProjector {
         || (childRel instanceof SetOp)) {
       // if nothing is projected from the children, arbitrarily project
       // the first columns; this is necessary since Fennel doesn't
-      // handle 0-column projections
-      if (nProject == 0 && childPreserveExprs.isEmpty()) {
+      // handle 0-column projections.
+      //
+      // An input may legitimately have a zero-column row type: for
+      // example, a Values with an empty row type and a single empty
+      // tuple, which returns one row with zero columns and is the
+      // identity for cross join. There is no first column to fall back
+      // on in that case, so skip the workaround rather than set a bit
+      // that points past the input's fields; createProjectRefsAndExprs
+      // would use it to index into an empty field list.
+      if (nProject == 0 && childPreserveExprs.isEmpty() && nFields > 0) {
         projRefs.set(0);
         nProject = 1;
       }
       if (childRel instanceof Join) {
-        if (nRightProject == 0 && rightPreserveExprs.isEmpty()) {
+        if (nRightProject == 0 && rightPreserveExprs.isEmpty()
+            && nFieldsRight > 0) {
           projRefs.set(nFields);
           nRightProject = 1;
         }

--- a/core/src/main/java/org/apache/calcite/rel/rules/PushProjector.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PushProjector.java
@@ -459,12 +459,13 @@ public class PushProjector {
       // the first columns; this is necessary since Fennel doesn't
       // handle 0-column projections.
       //
-      // An input may legitimately have a zero-column row type -- for
-      // example DEE, the empty-row-type Values that is the identity for
-      // cross join. There is no first column to fall back on in that
-      // case, so skip the workaround rather than set a bit that points
-      // past the input's fields; createProjectRefsAndExprs would use it
-      // to index into an empty field list.
+      // An input may legitimately have a zero-column row type: for
+      // example, a Values with an empty row type and a single empty
+      // tuple, which returns one row with zero columns and is the
+      // identity for cross join. There is no first column to fall back
+      // on in that case, so skip the workaround rather than set a bit
+      // that points past the input's fields; createProjectRefsAndExprs
+      // would use it to index into an empty field list.
       if (nProject == 0 && childPreserveExprs.isEmpty() && nFields > 0) {
         projRefs.set(0);
         nProject = 1;

--- a/core/src/main/java/org/apache/calcite/rel/rules/PushProjector.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/PushProjector.java
@@ -457,13 +457,21 @@ public class PushProjector {
         || (childRel instanceof SetOp)) {
       // if nothing is projected from the children, arbitrarily project
       // the first columns; this is necessary since Fennel doesn't
-      // handle 0-column projections
-      if (nProject == 0 && childPreserveExprs.isEmpty()) {
+      // handle 0-column projections.
+      //
+      // An input may legitimately have a zero-column row type -- for
+      // example DEE, the empty-row-type Values that is the identity for
+      // cross join. There is no first column to fall back on in that
+      // case, so skip the workaround rather than set a bit that points
+      // past the input's fields; createProjectRefsAndExprs would use it
+      // to index into an empty field list.
+      if (nProject == 0 && childPreserveExprs.isEmpty() && nFields > 0) {
         projRefs.set(0);
         nProject = 1;
       }
       if (childRel instanceof Join) {
-        if (nRightProject == 0 && rightPreserveExprs.isEmpty()) {
+        if (nRightProject == 0 && rightPreserveExprs.isEmpty()
+            && nFieldsRight > 0) {
           projRefs.set(nFields);
           nRightProject = 1;
         }

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -1559,6 +1559,56 @@ class RelOptRulesTest extends RelOptTestBase {
     checkJoinProjectTransposeDoesNotMatch(JoinRelType.LEFT_MARK);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7487">[CALCITE-7487]
+   * ProjectJoinTransposeRule throws ArrayIndexOutOfBoundsException in
+   * PushProjector when a Join input has a zero-column row type</a>. */
+  @Test void testProjectJoinTransposeWithZeroColumnRightInput() {
+    relFn(b -> zeroColumnJoinInputRelFn(b, false))
+        .withRule(CoreRules.PROJECT_JOIN_TRANSPOSE).check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7487">[CALCITE-7487]
+   * ProjectJoinTransposeRule throws ArrayIndexOutOfBoundsException in
+   * PushProjector when a Join input has a zero-column row type</a>. */
+  @Test void testProjectJoinTransposeWithZeroColumnLeftInput() {
+    relFn(b -> zeroColumnJoinInputRelFn(b, true))
+        .withRule(CoreRules.PROJECT_JOIN_TRANSPOSE).check();
+  }
+
+  /** Builds {@code Project(CAST(col1))} over a cross join in which one input is
+   * DEE -- a {@link org.apache.calcite.rel.core.Values} with an empty row type,
+   * the identity for cross join. The project must be non-identity, otherwise
+   * {@link RelBuilder} collapses it away and the rule never fires. */
+  private static RelNode zeroColumnJoinInputRelFn(RelBuilder b,
+      boolean deeOnLeft) {
+    final RelDataTypeFactory typeFactory = b.getTypeFactory();
+    final RelDataType bigintType =
+        typeFactory.createSqlType(SqlTypeName.BIGINT);
+    final RelNode nonEmpty = b
+        .values(
+            ImmutableList.of(
+                ImmutableList.of(
+                    (RexLiteral) b.getRexBuilder().makeZeroLiteral(bigintType))),
+            typeFactory.builder().add("col1", bigintType).build())
+        .build();
+    final RelNode dee = b
+        .values(ImmutableList.of(ImmutableList.of()),
+            typeFactory.builder().build())
+        .build();
+    final RelDataType varcharType =
+        typeFactory.createSqlType(SqlTypeName.VARCHAR);
+    return b
+        .push(deeOnLeft ? dee : nonEmpty)
+        .push(deeOnLeft ? nonEmpty : dee)
+        .join(JoinRelType.INNER, b.literal(true))
+        // DEE contributes no fields, so the sole column is at index 0
+        // whichever side it is on.
+        .project(b.getRexBuilder().makeCast(varcharType, b.field(0)))
+        .build();
+  }
+
   /** A SEMI, ANTI or LEFT_MARK join does not project its right input, so
    * {@link JoinProjectTransposeRule} must not pull projects above it. */
   private void checkJoinProjectTransposeDoesNotMatch(JoinRelType type) {

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -12483,6 +12483,44 @@ LogicalProject(DEPTNO=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testProjectJoinTransposeWithZeroColumnLeftInput">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(col1=[CAST($0):VARCHAR NOT NULL])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalValues(tuples=[[{  }]])
+    LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[true], joinType=[inner])
+  LogicalProject
+    LogicalValues(tuples=[[{  }]])
+  LogicalProject(col1=[CAST($0):VARCHAR NOT NULL])
+    LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinTransposeWithZeroColumnRightInput">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(col1=[CAST($0):VARCHAR NOT NULL])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalValues(tuples=[[{ 0 }]])
+    LogicalValues(tuples=[[{  }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[true], joinType=[inner])
+  LogicalProject(col1=[CAST($0):VARCHAR NOT NULL])
+    LogicalValues(tuples=[[{ 0 }]])
+  LogicalProject
+    LogicalValues(tuples=[[{  }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testProjectMergeRuleWithCorrelation">
     <Resource name="sql">
       <![CDATA[SELECT ARRAY(SELECT y + 1 FROM UNNEST(s.x) y)

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -12362,6 +12362,44 @@ LogicalProject(DEPTNO=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testProjectJoinTransposeWithZeroColumnLeftInput">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(col1=[CAST($0):VARCHAR NOT NULL])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalValues(tuples=[[{  }]])
+    LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[true], joinType=[inner])
+  LogicalProject
+    LogicalValues(tuples=[[{  }]])
+  LogicalProject(col1=[CAST($0):VARCHAR NOT NULL])
+    LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProjectJoinTransposeWithZeroColumnRightInput">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(col1=[CAST($0):VARCHAR NOT NULL])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalValues(tuples=[[{ 0 }]])
+    LogicalValues(tuples=[[{  }]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalJoin(condition=[true], joinType=[inner])
+  LogicalProject(col1=[CAST($0):VARCHAR NOT NULL])
+    LogicalValues(tuples=[[{ 0 }]])
+  LogicalProject
+    LogicalValues(tuples=[[{  }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testProjectMergeRuleWithCorrelation">
     <Resource name="sql">
       <![CDATA[SELECT ARRAY(SELECT y + 1 FROM UNNEST(s.x) y)


### PR DESCRIPTION
`PushProjector.locateAllRefs` contains a workaround, originally added for Fennel, that arbitrarily projects the first column of a `Join`/`SetOp` input when nothing else is projected from it:

```java
if (nProject == 0 && childPreserveExprs.isEmpty()) {
  projRefs.set(0);
  nProject = 1;
}
```

It assumes the input *has* a first column. That fails for a zero-column input — canonically DEE, the `Values` with an empty row type and a single empty tuple that is the identity for cross join (it arises when an `Aggregate` with `GROUP BY ()` has its output pruned to zero columns). The workaround then sets a bit past the input's fields, and `createProjectRefsAndExprs` uses it to index into an empty field list:

```
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
    at org.apache.calcite.rel.rules.PushProjector.createProjectRefsAndExprs(PushProjector.java:523)
    at org.apache.calcite.rel.rules.ProjectJoinTransposeRule.onMatch(ProjectJoinTransposeRule.java:117)
```

### Fix

Guard each workaround on the input it protects having at least one field: `nFields > 0` for the left, `nFieldsRight > 0` for the right. When there is genuinely no first column, the workaround is skipped instead of producing an out-of-range reference.

### Two deviations from the JIRA description, both verified

**1. The left-side case is not merely latent — it crashes too.** The ticket notes the symmetric `nProject == 0` path "has the same latent issue" but that only the right-side variant had been seen in practice. Putting DEE on the *left* of the cross join throws the identical exception, so there is a regression test for each direction.

**2. The suggested left-side guard `(nSysFields + nFields) > 0` would not be correct.** Given the field layout documented on `nFields`:

```
| nSysFields | nFields | nFieldsRight |
```

the left input has `nFields` fields, so folding `nSysFields` into the condition lets the workaround through when `nSysFields > 0 && nFields == 0`. `createProjectRefsAndExprs` uses `offset = nSysFields` for the left side, so `refIdx - offset` would then be negative — a different crash rather than a fix. Hence `nFields > 0`.

### Note on the resulting plan

Skipping the workaround means the pushed-down projection over the zero-column input is itself zero-column:

```
LogicalJoin(condition=[true], joinType=[inner])
  LogicalProject(col1=[CAST($0):VARCHAR NOT NULL])
    LogicalValues(tuples=[[{ 0 }]])
  LogicalProject
    LogicalValues(tuples=[[{  }]])
```

That is precisely what the Fennel workaround existed to avoid. Fennel has long been removed, and zero-column relational expressions are legal in Calcite today — DEE itself is one — so this seems right. Flagging it explicitly in case anyone disagrees, since it is the behavioural part of this change.

### Out of scope, but worth recording

`projRefs.set(0)` and `projRefs.set(nFields)` look like they should be `set(nSysFields)` and `set(nSysFields + nFields)`, since the left input's fields start after the system fields. Demonstrating that needs a Join that actually has system fields, and fixing it would change which column the workaround picks, so I have deliberately kept it out of this crash fix. Happy to file it separately if it is a real issue.

The reporter also wondered whether `ProjectCorrelateTransposeRule` has the same latent issue. It does construct a `PushProjector` (`ProjectCorrelateTransposeRule.java:79-80`), but the workaround is gated on `childRel instanceof Join || childRel instanceof SetOp`, and `Correlate extends BiRel` — it is neither. So that rule never reaches this code and is unaffected.

### Tests

Both new tests fail on current `main` with the `ArrayIndexOutOfBoundsException` above and pass with the fix. `RelOptRulesTest` is green (923 tests). Golden plans were produced via the standard `_actual.xml` mechanism.
