### PR TITLE
Add AGENTS.md so the threat model is discoverable by agents

### DIFF
--- a/.ratignore
+++ b/.ratignore
@@ -14,6 +14,7 @@
 **/data2.txt
 .idea/vcs.xml
 SECURITY.md
+AGENTS.md
 example/csv/src/test/resources/smoke_test.sql
 
 # TODO: remove when pom.xml files are removed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Agent guidance
+
+This file is read by automated agents (security scanners, code analyzers,
+AI assistants) operating on this repository. It points them at the
+human-authored references they should consult before producing output.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md), which links to the project's
+threat model at
+[site/_docs/security_threat_model.md](./site/_docs/security_threat_model.md).
+
+Calcite is an embedded SQL framework, not a server. It opens no socket and
+has no authentication or authorization of its own; the host application
+owns transport, identity, and schema scoping. Read the threat model before
+reporting anything — it is explicit about what it does and does not treat
+as a vulnerability.
+
+Two rules carry most of the triage weight:
+
+- **Surprising vs unsurprising class loading.** A class named through a
+  Calcite SPI position — `schemaFactory`, `parserFactory`, `typeSystem`,
+  `metaTableFactory`, `metaColumnFactory`, `tableFactory`, function
+  classes, `dataSource`, `jdbcDriver`, `model` — is loaded only through
+  that SPI, gated by `Class.forName(name, false, loader)` plus an
+  `isAssignableFrom` check. A class that does not implement the SPI for
+  its position is never instantiated by name. SQL may name SPI classes,
+  but only SPI implementations run, and only through their SPI.
+- **Pushed-down SQL.** The SQL Calcite generates and sends to a backend
+  the operator configured is *not* a vulnerability — the query author can
+  already reach that endpoint through the visible schemas. A pushdown bug
+  that reads *beyond* the configured schemas is P4 and *is* one.
+
+Explicitly not vulnerabilities (see the model's "Not a vulnerability"
+section): the os-adapter running OS commands, the file/CSV/JSON adapters
+reading paths they were configured with, anything requiring a changed
+system property or classpath, a third-party driver's behaviour past the
+connection boundary, and cross-tenant reads that follow from the embedder
+exposing several principals' schemas on one connection.
+
+The model also lists what belongs to the host rather than the library —
+transport and identity, schema scoping, adapter selection, the classpath,
+and whatever a `model` points at — under "Downstream responsibilities".


### PR DESCRIPTION
## What

Adds an `AGENTS.md` at the repository root pointing at `SECURITY.md`, and adds it to `.ratignore` alongside `SECURITY.md`.

## Why

CALCITE-7605 landed the threat model at `site/_docs/security_threat_model.md` together with a `SECURITY.md` that links to it. That part is complete and reads well.

What is missing is the entry point. Automated agents — security scanners, code analyzers, coding assistants — locate a project's security model by following a fixed chain:

```
AGENTS.md  ->  SECURITY.md  ->  the threat model
```

`apache/calcite` has the second and third hops but not the first, so the chain cannot be walked mechanically and an agent starting from a clone has no way to find the model on its own.

This matters concretely for the ASF Security team's scanning programme: we refuse to run a scan against a project whose model is not mechanically discoverable, because without the model in context the false-positive rate is more than a PMC can reasonably triage. This PR closes that gap for Calcite.

## What is in the file

No new claims — everything restates the merged model:

- A pointer to `SECURITY.md` and onward to `site/_docs/security_threat_model.md`.
- The framing that Calcite is embedded, opens no socket, and has no authentication or authorization of its own.
- The two rules that carry most of the triage weight: the **surprising vs unsurprising class loading** gate (only SPI implementations are instantiated by name, via `Class.forName(name, false, loader)` plus `isAssignableFrom`, across the enumerated SPI positions), and the **pushed-down SQL** split (generated SQL reaching a configured backend is not a vulnerability; a pushdown bug reading beyond the configured schemas is P4 and is one).
- Signposts to the model's "Not a vulnerability" and "Downstream responsibilities" sections.

## Notes for reviewers

- **Docs only.** No production code is touched.
- **`.ratignore`:** `AGENTS.md` carries no license header, so it is excluded exactly as CALCITE-7605 excluded `SECURITY.md`. Happy to add a header and drop the `.ratignore` line instead if the PMC prefers that direction.
- **No JIRA reference in the title.** CALCITE-7605 is resolved, and I did not want to reopen it or file a ticket on the project's behalf unprompted. If Calcite would like a JIRA for this, say the word and I will file one and retitle the PR to match the `[CALCITE-NNNN]` convention.
- I deliberately did **not** link the rendered site URL for the threat model, since it does not resolve yet — the in-repo path is what an agent follows anyway.

Opened by the ASF Security team as part of the Frontier Model Preparation scan pre-flight for Calcite, following the request on the PMC's `[GLASSWING]` thread. Review, change, or close as the PMC sees fit — the document is the project's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
