### PR TITLE
[CALCITE-7681] SqlDatetimeSubtractionOperator drops parentheses around compound interval expressions

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -496,9 +496,9 @@ public class SqlDialect {
   public void unparseSqlDatetimeArithmetic(SqlWriter writer,
       SqlCall call, SqlKind sqlKind, int leftPrec, int rightPrec) {
     final SqlWriter.Frame frame = writer.startList("(", ")");
-    call.operand(0).unparse(writer, leftPrec, rightPrec);
+    call.operand(0).unparse(writer, leftPrec, call.getOperator().getLeftPrec());
     writer.sep((SqlKind.PLUS == sqlKind) ? "+" : "-");
-    call.operand(1).unparse(writer, leftPrec, rightPrec);
+    call.operand(1).unparse(writer, call.getOperator().getRightPrec(), rightPrec);
     writer.endList(frame);
     // Only two parameters are present normally.
     // Checking parameter count to prevent errors.

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -561,6 +561,20 @@ class RelToSqlConverterTest {
         .withOracle().ok(expectedOracle);
   }
 
+  @Test void testDatetimeSubtractionWithCompoundInterval() {
+    final String query = "select CURRENT_DATE"
+        + " - (INTERVAL '3' YEAR + INTERVAL '3' YEAR) as d";
+    final String expected = "SELECT (CURRENT_DATE"
+        + " - (INTERVAL '3' YEAR + INTERVAL '3' YEAR)) AS \"D\"\n"
+        + "FROM (VALUES (0)) AS \"t\" (\"ZERO\")";
+    final String expectedSpark = "SELECT (CURRENT_DATE"
+        + " - (INTERVAL '3' YEAR + INTERVAL '3' YEAR)) `D`\n"
+        + "FROM (VALUES (0)) `t` (`ZERO`)";
+    sql(query)
+        .ok(expected)
+        .withSpark().ok(expectedSpark);
+  }
+
   @Test void testPivotToSqlFromProductTable() {
     String query = "select * from (\n"
         + "  select \"shelf_width\", \"net_weight\", \"product_id\"\n"


### PR DESCRIPTION
## Jira Link

[CALCITE-7681](https://issues.apache.org/jira/browse/CALCITE-7681)

## Changes Proposed

Apply the datetime operator's precedence when unparsing its operands. This preserves the compound interval in SQL such as:

```sql
CURRENT_DATE - (INTERVAL '3' YEAR + INTERVAL '3' YEAR)
```

Previously, RelToSql flattened the right operand and changed the expression's meaning:

```sql
CURRENT_DATE - INTERVAL '3' YEAR + INTERVAL '3' YEAR
```

Add regression coverage for the default and Spark dialects.