### PR TITLE
[CALCITE-7554] NlsString.compareTo inconsistent with equals/hashCode

### DIFF
--- a/core/src/main/java/org/apache/calcite/util/NlsString.java
+++ b/core/src/main/java/org/apache/calcite/util/NlsString.java
@@ -38,6 +38,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -185,10 +186,34 @@ public class NlsString implements Comparable<NlsString>, Cloneable {
   }
 
   @Override public int compareTo(NlsString other) {
+    int cmp;
     if (collation != null && collation.getCollator() != null) {
-      return collation.getCollator().compare(getValue(), other.getValue());
+      cmp = collation.getCollator().compare(getValue(), other.getValue());
+    } else {
+      cmp = getValue().compareTo(other.getValue());
     }
-    return getValue().compareTo(other.getValue());
+    if (cmp != 0) {
+      return cmp;
+    }
+    cmp =
+        Objects.compare(
+            charsetName, other.charsetName,
+            Comparator.nullsFirst(String::compareTo));
+    if (cmp != 0) {
+      return cmp;
+    }
+    cmp =
+        Objects.compare(
+            collation, other.collation,
+            Comparator.nullsFirst(
+                Comparator.comparing(Object::toString)));
+    if (cmp != 0) {
+      return cmp;
+    }
+    // Ensures compareTo==0 <-> equals==true
+    return Objects.compare(
+        bytesValue, other.bytesValue,
+        Comparator.nullsFirst(Comparator.naturalOrder()));
   }
 
   @Pure

--- a/core/src/test/java/org/apache/calcite/util/UtilTest.java
+++ b/core/src/test/java/org/apache/calcite/util/UtilTest.java
@@ -3002,6 +3002,59 @@ class UtilTest {
     assertThat(s2, hasToString(s.toString()));
   }
 
+  /** Tests that {@link NlsString#compareTo} is consistent with
+   * {@link NlsString#equals}: {@code x.compareTo(y) == 0} iff
+   * {@code x.equals(y)} for values that differ in charset or collation. */
+  @Test void testNlsStringCompareToConsistency() {
+    // ("hello","LATIN1",null) vs ("hello","UTF-8",null) -> equals=false, compareTo!=0
+    final NlsString latin1 = new NlsString("hello", "LATIN1", null);
+    final NlsString utf8 = new NlsString("hello", "UTF-8", null);
+    assertThat(latin1.equals(utf8), is(false));
+    assertThat(latin1.compareTo(utf8), not(equalTo(0)));
+
+    // ("hello","UTF-8",null) vs ("hello","UTF-8",IMPLICIT) -> equals=false, compareTo!=0
+    final NlsString noColl = new NlsString("hello", "UTF-8", null);
+    final NlsString withColl =
+        new NlsString("hello", "UTF-8", SqlCollation.IMPLICIT);
+    assertThat(noColl.equals(withColl), is(false));
+    assertThat(noColl.compareTo(withColl), not(equalTo(0)));
+
+    // ("hello","UTF-8",IMPLICIT) vs ("hello","UTF-8",IMPLICIT) -> equals=true, compareTo==0
+    final NlsString a = new NlsString("hello", "UTF-8", SqlCollation.IMPLICIT);
+    final NlsString b = new NlsString("hello", "UTF-8", SqlCollation.IMPLICIT);
+    assertThat(a.equals(b), is(true));
+    assertThat(a.compareTo(b), is(0));
+
+    // ("hello",null,null) vs ("hello",null,null) -> equals=true, compareTo==0
+    final NlsString n1 = new NlsString("hello", null, null);
+    final NlsString n2 = new NlsString("hello", null, null);
+    assertThat(n1.equals(n2), is(true));
+    assertThat(n1.compareTo(n2), is(0));
+
+    // ("hello",null,null) vs ("hello","UTF-8",null) -> equals=false, compareTo!=0
+    final NlsString n3 = new NlsString("hello", null, null);
+    final NlsString n4 = new NlsString("hello", "UTF-8", null);
+    assertThat(n3.equals(n4), is(false));
+    assertThat(n3.compareTo(n4), not(equalTo(0)));
+  }
+
+  @Test void testNlsStringTreeSetRetainsDistinctValues() {
+    // 4 values, same string "hello", different charset: TreeSet must keep all 4
+    // Before fix: compareTo ignored charset, TreeSet collapsed them into 1
+    final NlsString s1 = new NlsString("hello", "LATIN1", null);
+    final NlsString s2 = new NlsString("hello", "UTF-8", null);
+    final NlsString s3 = new NlsString("hello", "UTF-16", null);
+    final NlsString s4 = new NlsString("hello", null, null);
+
+    final SortedSet<NlsString> set = new TreeSet<>(Arrays.asList(s1, s2, s3, s4));
+    assertThat(set, hasSize(4));
+
+    // Add exact duplicate of s1: set size unchanged
+    final NlsString s1dup = new NlsString("hello", "LATIN1", null);
+    set.add(s1dup);
+    assertThat(set, hasSize(4));
+  }
+
   @Test void testCollationEncoding() {
     SqlCollation collation =
         new SqlCollation(


### PR DESCRIPTION
## What

`NlsString.compareTo()` only compared the decoded string value, ignoring `charsetName`, `collation`, and `bytesValue`. This made `compareTo` inconsistent with `equals()`/`hashCode()`, which consider all metadata fields.

## Why It Matters

This violates the Java contract: when `equals() == true`, `compareTo() == 0` must also hold. The bug caused `TreeSet` and `TreeMap` to silently collapse distinct `NlsString` values that shared the same decoded string but differed in charset or collation.

Example: `("hello", "LATIN1", null)` and `("hello", "UTF-8", null)` are not equal per `equals()`, but the old `compareTo()` returned 0 — causing a `TreeSet` to keep only one of them.

## Changes

**`NlsString.java`** (+32 -2):
- After comparing decoded string values (preserving the original collator branch), break ties by comparing:
  1. `charsetName` — `Comparator.nullsFirst(String::compareTo)` for null safety
  2. `collation` — `SqlCollation` does not implement `Comparable`, so `toString()` is used as proxy key
  3. `bytesValue` — `ByteString` implements `Comparable<ByteString>`, using `Comparator.naturalOrder()`
- All comparisons use `Comparator.nullsFirst()` for null-safe handling (fields are `@Nullable`)
- No new helper methods — standard library `Comparator` utilities only

**`UtilTest.java`** (+53):
- `testNlsStringCompareToConsistency()`: 5 cases verifying `compareTo`/`equals` consistency:
  - Same text, different charset → not equal, `compareTo != 0`
  - Same text, different collation → not equal, `compareTo != 0`
  - Identical values → equal, `compareTo == 0`
  - Both null charset → equal, `compareTo == 0`
  - One null, one non-null charset → not equal, `compareTo != 0`
- `testNlsStringTreeSetRetainsDistinctValues()`: 4 values with same string "hello" but different charset — TreeSet must retain all 4 (before fix: collapsed to 1)

## Verification

- `./gradlew :core:compileJava` — BUILD SUCCESSFUL
- `./gradlew :core:checkstyleMain` — passed
- `./gradlew :core:test --tests "org.apache.calcite.util.UtilTest"` — 7 tests passed

## Note

This is a behavior change: `TreeSet<NlsString>` ordering results may differ from before. This is the intended fix — the old behavior was a bug.

## Jira

[CALCITE-7554](https://issues.apache.org/jira/browse/CALCITE-7554)