### PR TITLE
[CALCITE-7601] Harden ST_GeomFromGML against XXE attacks

### DIFF
--- a/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
+++ b/core/src/main/java/org/apache/calcite/runtime/SpatialTypeUtils.java
@@ -31,14 +31,19 @@ import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.io.WKTWriter;
 import org.locationtech.jts.io.geojson.GeoJsonReader;
 import org.locationtech.jts.io.geojson.GeoJsonWriter;
-import org.locationtech.jts.io.gml2.GMLReader;
+import org.locationtech.jts.io.gml2.GMLHandler;
 import org.locationtech.jts.io.gml2.GMLWriter;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.io.StringReader;
 import java.util.Locale;
 import java.util.regex.Pattern;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 
 import static java.lang.Integer.parseInt;
 
@@ -130,13 +135,35 @@ public class SpatialTypeUtils {
   /**
    * Constructs a geometry from a GML representation.
    *
+   * <p>The XML parser is configured to reject DOCTYPE declarations and
+   * disable external entity expansion to prevent XXE attacks.
+   *
    * @param gml a GML
    * @return a geometry
    */
   public static Geometry fromGml(String gml) {
+    if (gml == null || gml.isEmpty()) {
+      throw new RuntimeException("Unable to parse GML");
+    }
     try {
-      GMLReader reader = new GMLReader();
-      return reader.read(gml, GEOMETRY_FACTORY);
+      SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
+      saxParserFactory.setValidating(false);
+      saxParserFactory.setNamespaceAware(false);
+      // Harden against XXE: disallow DOCTYPE declarations and disable
+      // external entity expansion.
+      saxParserFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      saxParserFactory.setFeature(
+          "http://apache.org/xml/features/disallow-doctype-decl", true);
+      saxParserFactory.setFeature(
+          "http://xml.org/sax/features/external-general-entities", false);
+      saxParserFactory.setFeature(
+          "http://xml.org/sax/features/external-parameter-entities", false);
+      saxParserFactory.setFeature(
+          "http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+      SAXParser saxParser = saxParserFactory.newSAXParser();
+      GMLHandler handler = new GMLHandler(GEOMETRY_FACTORY, null);
+      saxParser.parse(new InputSource(new StringReader(gml)), handler);
+      return handler.getGeometry();
     } catch (SAXException | IOException | ParserConfigurationException e) {
       throw new RuntimeException("Unable to parse GML");
     }

--- a/core/src/test/java/org/apache/calcite/runtime/SpatialTypeUtilsTest.java
+++ b/core/src/test/java/org/apache/calcite/runtime/SpatialTypeUtilsTest.java
@@ -23,6 +23,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests {@link org.apache.calcite.runtime.SpatialTypeUtilsTest}.
@@ -52,5 +53,36 @@ class SpatialTypeUtilsTest {
     Geometry g1 = gf.createPoint(new Coordinate(1, 2));
     g1.setSRID(1234);
     assertThat(SpatialTypeUtils.asEwkt(g1), is("srid:1234;POINT (1 2)"));
+  }
+
+  @Test void testFromGml() {
+    GeometryFactory gf = new GeometryFactory();
+    Geometry point = gf.createPoint(new Coordinate(1, 2));
+    String gml = SpatialTypeUtils.asGml(point);
+    Geometry parsed = SpatialTypeUtils.fromGml(gml);
+    assertThat(parsed.getCoordinate().getX(), is(1D));
+    assertThat(parsed.getCoordinate().getY(), is(2D));
+  }
+
+  @Test void testFromGmlRejectsDoctype() {
+    String gmlWithDoctype = "<!DOCTYPE foo><gml:Point>"
+        + "<gml:coordinates>1,2</gml:coordinates></gml:Point>";
+    RuntimeException e =
+        assertThrows(RuntimeException.class, () -> SpatialTypeUtils.fromGml(gmlWithDoctype));
+    assertThat(e.getMessage(), is("Unable to parse GML"));
+  }
+
+  @Test void testFromGmlRejectsXxeExternalEntity() {
+    String maliciousGml = "<!DOCTYPE foo [ <!ENTITY xxe SYSTEM "
+        + "\"file:///etc/passwd\"> ]>"
+        + "<gml:Point><gml:coordinates>&xxe;,0</gml:coordinates></gml:Point>";
+    RuntimeException e =
+        assertThrows(RuntimeException.class, () -> SpatialTypeUtils.fromGml(maliciousGml));
+    assertThat(e.getMessage(), is("Unable to parse GML"));
+  }
+
+  @Test void testFromGmlRejectsNullOrEmpty() {
+    assertThrows(RuntimeException.class, () -> SpatialTypeUtils.fromGml(null));
+    assertThrows(RuntimeException.class, () -> SpatialTypeUtils.fromGml(""));
   }
 }


### PR DESCRIPTION
## What

`ST_GeomFromGML` did not disable external entity expansion when parsing GML input, allowing XXE (XML External Entity) attacks via crafted GML strings containing `<!DOCTYPE>` declarations.

## Fix

Configure the XML parser with:
- `disallow-doctype-decl = true`
- `external-general-entities = false`
- `external-parameter-entities = false`
- `load-external-dtd = false`

## Tests

- Normal GML strings still parse correctly
- Malicious GML with DOCTYPE + external entity is rejected
- Empty/null input handled gracefully

## Jira

[CALCITE-7601](https://issues.apache.org/jira/browse/CALCITE-7601)