### PR TITLE
[CALCITE-7690] DELETE on a single-column table fails with "Cannot cast java.lang.Object to int"

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableModify.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableModify.java
@@ -312,12 +312,7 @@ public class EnumerableTableModify extends TableModify
 
     // Build sink key extractor by reading table fields from each sink row.
     final ParameterExpression sinkRow = Expressions.parameter(Object.class, "sinkRow");
-    // Box the target type. For a single-column table the physical row format is
-    // SCALAR, so the Java row type is a primitive, and "(int) sinkRow" is a cast
-    // from Object to a primitive. Java allows that (JLS 5.5: narrowing reference
-    // conversion followed by unboxing) but Janino does not implement it, so the
-    // generated code fails to compile. Primitive.box leaves Object[] unchanged,
-    // which is the multi-column case.
+    // Box, because Janino cannot cast Object to a primitive.
     final Expression typedSinkRow =
         Expressions.convert_(sinkRow,
             Primitive.box(tablePhysType.getJavaRowType()));

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableModify.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableTableModify.java
@@ -24,6 +24,7 @@ import org.apache.calcite.linq4j.tree.BlockBuilder;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
 import org.apache.calcite.linq4j.tree.ParameterExpression;
+import org.apache.calcite.linq4j.tree.Primitive;
 import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelOptTable;
@@ -311,8 +312,15 @@ public class EnumerableTableModify extends TableModify
 
     // Build sink key extractor by reading table fields from each sink row.
     final ParameterExpression sinkRow = Expressions.parameter(Object.class, "sinkRow");
+    // Box the target type. For a single-column table the physical row format is
+    // SCALAR, so the Java row type is a primitive, and "(int) sinkRow" is a cast
+    // from Object to a primitive. Java allows that (JLS 5.5: narrowing reference
+    // conversion followed by unboxing) but Janino does not implement it, so the
+    // generated code fails to compile. Primitive.box leaves Object[] unchanged,
+    // which is the multi-column case.
     final Expression typedSinkRow =
-        Expressions.convert_(sinkRow, tablePhysType.getJavaRowType());
+        Expressions.convert_(sinkRow,
+            Primitive.box(tablePhysType.getJavaRowType()));
     final List<Expression> sinkValues = new ArrayList<>(fieldCount);
     for (int i = 0; i < fieldCount; i++) {
       sinkValues.add(tablePhysType.fieldReference(typedSinkRow, i, Object.class));

--- a/server/src/test/java/org/apache/calcite/test/ServerTest.java
+++ b/server/src/test/java/org/apache/calcite/test/ServerTest.java
@@ -241,6 +241,77 @@ class ServerTest {
     }
   }
 
+  /** Tests DELETE on a single-column table, whose Java row type is a
+   * primitive. */
+  @Test void testDeleteSingleColumn() throws Exception {
+    try (Connection c = connect();
+         Statement s = c.createStatement()) {
+      s.execute("create table t (i int not null)");
+      s.executeUpdate("insert into t values (1)");
+      s.executeUpdate("insert into t values (2)");
+      s.executeUpdate("insert into t values (3)");
+
+      // Delete 0 rows (no predicate match)
+      int count = s.executeUpdate("delete from t where i = 99");
+      assertThat(count, is(0));
+
+      // Delete 1 row
+      count = s.executeUpdate("delete from t where i = 2");
+      assertThat(count, is(1));
+
+      try (ResultSet r = s.executeQuery("select count(*) from t")) {
+        assertThat(r.next(), is(true));
+        assertThat(r.getInt(1), is(2));
+      }
+
+      // Delete the two remaining rows
+      count = s.executeUpdate("delete from t where i > 0");
+      assertThat(count, is(2));
+
+      try (ResultSet r = s.executeQuery("select count(*) from t")) {
+        assertThat(r.next(), is(true));
+        assertThat(r.getInt(1), is(0));
+      }
+    }
+  }
+
+  /** Tests DELETE on a single-column table whose Java row type is already a
+   * reference. */
+  @Test void testDeleteSingleObjectColumn() throws Exception {
+    try (Connection c = connect();
+         Statement s = c.createStatement()) {
+      s.execute("create table t (v varchar(10) not null)");
+      s.executeUpdate("insert into t values ('a')");
+      s.executeUpdate("insert into t values ('b')");
+
+      final int count = s.executeUpdate("delete from t where v = 'a'");
+      assertThat(count, is(1));
+
+      try (ResultSet r = s.executeQuery("select count(*) from t")) {
+        assertThat(r.next(), is(true));
+        assertThat(r.getInt(1), is(1));
+      }
+    }
+  }
+
+  /** Tests DELETE on a nullable single-column table. */
+  @Test void testDeleteSingleNullableColumn() throws Exception {
+    try (Connection c = connect();
+         Statement s = c.createStatement()) {
+      s.execute("create table t (i int)");
+      s.executeUpdate("insert into t values (1)");
+      s.executeUpdate("insert into t values (2)");
+
+      final int count = s.executeUpdate("delete from t where i = 1");
+      assertThat(count, is(1));
+
+      try (ResultSet r = s.executeQuery("select count(*) from t")) {
+        assertThat(r.next(), is(true));
+        assertThat(r.getInt(1), is(1));
+      }
+    }
+  }
+
   @Test void testDeleteDuplicateRows() throws Exception {
     try (Connection c = connect();
          Statement s = c.createStatement()) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/CALCITE-7690

`DELETE` on a single-column table generates `(int) sinkRow` from a `sinkRow` declared `Object`, because for
one column the table's Java row type is a primitive. javac accepts that cast; Janino does not, so the
generated code fails to compile.

Boxing the target type fixes it. `Primitive.box` leaves references unchanged, so the multi-column case is
unaffected.

Tests: `ServerTest.testDeleteSingleColumn`, `testDeleteSingleObjectColumn` and
`testDeleteSingleNullableColumn`. The tests added by [CALCITE-7510] are all two-column, so this shape was
never covered.
