### PR TITLE
[CALCITE-5998] The SAFE_OFFSET operator can cause an index out of bounds exception

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlOperatorUnparseTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlOperatorUnparseTest.java
@@ -24,8 +24,6 @@ import org.apache.calcite.sql.parser.StringAndPos;
 import org.apache.calcite.sql.test.SqlOperatorFixture;
 import org.apache.calcite.sql.test.SqlTestFactory;
 
-import org.junit.jupiter.api.Disabled;
-
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
@@ -104,14 +102,5 @@ public class SqlOperatorUnparseTest extends CalciteSqlOperatorTest {
         throw new RuntimeException(e);
       }
     }
-  }
-
-  // Every test that is Disabled below corresponds to a bug.
-  // These tests should just be deleted when the corresponding bugs are fixed.
-
-  @Override @Disabled("https://issues.apache.org/jira/browse/CALCITE-5998 "
-      + "The SAFE_OFFSET operator can cause an index out of bounds exception")
-  void testSafeOffsetOperator() {
-    super.testSafeOffsetOperator();
   }
 }

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -13851,6 +13851,17 @@ public class SqlOperatorTest {
     f.checkScalar("ARRAY[2,4,6][SAFE_OFFSET(-1)]", isNullValue(), "INTEGER");
     f.checkScalar("ARRAY[2,4,6][SAFE_OFFSET(5)]", isNullValue(), "INTEGER");
     f.checkNull("ARRAY[2,4,6][SAFE_OFFSET(null)]");
+    // Test case for [CALCITE-5998] The SAFE_OFFSET operator can cause
+    // an index out of bounds exception; the index is not constant
+    f.check("select ARRAY[p3,p2,p1][SAFE_OFFSET(p0)]\n"
+            + "from (values (-1, 6, 4, 2)) as t(p0, p1, p2, p3)",
+        "INTEGER", isNullValue());
+    f.check("select ARRAY[p3,p2,p1][SAFE_OFFSET(p1)]\n"
+            + "from (values (-1, 6, 4, 2)) as t(p0, p1, p2, p3)",
+        "INTEGER", isNullValue());
+    f.check("select ARRAY[p3,p2,p1][SAFE_OFFSET(p3)]\n"
+            + "from (values (-1, 6, 4, 2)) as t(p0, p1, p2, p3)",
+        "INTEGER", 6);
     f.checkFails("^map['foo', 3, 'bar', 7][safe_offset('bar')]^",
         "Cannot apply 'SAFE_OFFSET' to arguments of type 'SAFE_OFFSET\\(<MAP<CHAR\\(3\\)"
             + ", INTEGER>>, <CHAR\\(3\\)>\\)'\\. Supported form\\(s\\): "
@@ -13869,6 +13880,17 @@ public class SqlOperatorTest {
     f.checkScalar("ARRAY[2,4,6][SAFE_ORDINAL(-1)]", isNullValue(), "INTEGER");
     f.checkScalar("ARRAY[2,4,6][SAFE_ORDINAL(5)]", isNullValue(), "INTEGER");
     f.checkNull("ARRAY[2,4,6][SAFE_ORDINAL(null)]");
+    // Test case for [CALCITE-5998] The SAFE_OFFSET operator can cause
+    // an index out of bounds exception; the index is not constant
+    f.check("select ARRAY[p3,p2,p1][SAFE_ORDINAL(p0)]\n"
+            + "from (values (-1, 6, 4, 2)) as t(p0, p1, p2, p3)",
+        "INTEGER", isNullValue());
+    f.check("select ARRAY[p3,p2,p1][SAFE_ORDINAL(p1)]\n"
+            + "from (values (-1, 6, 4, 2)) as t(p0, p1, p2, p3)",
+        "INTEGER", isNullValue());
+    f.check("select ARRAY[p3,p2,p1][SAFE_ORDINAL(p3)]\n"
+            + "from (values (-1, 6, 4, 2)) as t(p0, p1, p2, p3)",
+        "INTEGER", 4);
     f.checkFails("^map['foo', 3, 'bar', 7][safe_ordinal('bar')]^",
         "Cannot apply 'SAFE_ORDINAL' to arguments of type 'SAFE_ORDINAL\\(<MAP<CHAR\\(3\\)"
             + ", INTEGER>>, <CHAR\\(3\\)>\\)'\\. Supported form\\(s\\): "


### PR DESCRIPTION
## Jira Link

[CALCITE-5998](https://issues.apache.org/jira/browse/CALCITE-5998)

## Changes Proposed

Ironically, this bug was fixed by [CALCITE-5997], but I filed it before I merged the other PR.
This PR only has tests to prove that the bug is fixed.