### PR TITLE
[CALCITE-7702] JoinAggregateTransposeRule produces a non-equivalent plan when the aggregate with empty input and empty group set

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/JoinAggregateTransposeRule.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/JoinAggregateTransposeRule.java
@@ -106,6 +106,11 @@ public class JoinAggregateTransposeRule
         // in case we decide to extend this rule for lazy aggregation.
         && isAggregateSupported(left, true)
         && groupOutput.contains(info.leftSet())
+        // An aggregate returns one row on empty input if its group set is empty.
+        // Pull-up adds group keys and may lose that row. Require the input to be
+        // known non-empty.
+        && (!left.getGroupSet().isEmpty()
+            || Boolean.FALSE.equals(mq.isEmpty(left.getInput())))
         // The right side must be unique on its join keys (no row duplication)
         && Boolean.TRUE.equals(mq.areColumnsUnique(right, info.rightSet()));
   }

--- a/core/src/test/java/org/apache/calcite/test/JoinAggregateTransposeRuleTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JoinAggregateTransposeRuleTest.java
@@ -161,6 +161,39 @@ class JoinAggregateTransposeRuleTest {
     sql(sql).withRule(CoreRules.JOIN_AGGREGATE_TRANSPOSE).checkUnchanged();
   }
 
+  /**
+   * Tests that the rule does not pull an aggregate with an empty group set when
+   * its input is empty.
+   */
+  @Test void testNoPullAggregateWithEmptyGroupSetOnEmptyInput() {
+    final String sql = "select g.emp_count, d.deptno\n"
+        + "from (select count(*) as emp_count from emp where false) g\n"
+        + "join (select deptno from dept where deptno = 10) d on true";
+    sql(sql).withRule(CoreRules.JOIN_AGGREGATE_TRANSPOSE).checkUnchanged();
+  }
+
+  /**
+   * Tests that the rule does not pull an aggregate with an empty group set when
+   * its input may be empty.
+   */
+  @Test void testNoPullAggregateWithEmptyGroupSetOnPotentiallyEmptyInput() {
+    final String sql = "select g.emp_count, d.deptno\n"
+        + "from (select count(*) as emp_count from emp) g\n"
+        + "join (select deptno from dept where deptno = 10) d on true";
+    sql(sql).withRule(CoreRules.JOIN_AGGREGATE_TRANSPOSE).checkUnchanged();
+  }
+
+  /**
+   * Tests that the rule pulls an aggregate with an empty group set when its
+   * input is known to be non-empty.
+   */
+  @Test void testPullAggregateWithEmptyGroupSetOnNonEmptyInput() {
+    final String sql = "select g.emp_count, d.deptno\n"
+        + "from (select count(*) as emp_count\n"
+        + "      from (values (1)) as v(n)) g\n"
+        + "join (select deptno from dept where deptno = 10) d on true";
+    sql(sql).withRule(CoreRules.JOIN_AGGREGATE_TRANSPOSE).check();
+  }
 
   @AfterAll static void checkActualAndReferenceFiles() {
     fixture().diffRepos.checkActualAndReferenceFiles();

--- a/core/src/test/resources/org/apache/calcite/test/JoinAggregateTransposeRuleTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/JoinAggregateTransposeRuleTest.xml
@@ -16,6 +16,45 @@
   ~ limitations under the License.
   -->
 <Root>
+  <TestCase name="testNoPullAggregateWithEmptyGroupSetOnEmptyInput">
+    <Resource name="sql">
+      <![CDATA[select g.emp_count, d.deptno
+from (select count(*) as emp_count from emp where false) g
+join (select deptno from dept where deptno = 10) d on true]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMP_COUNT=[$0], DEPTNO=[$1])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalAggregate(group=[{}], EMP_COUNT=[COUNT()])
+      LogicalProject($f0=[0])
+        LogicalFilter(condition=[false])
+          LogicalTableScan(table=[[scott, EMP]])
+    LogicalProject(DEPTNO=[$0])
+      LogicalFilter(condition=[=(CAST($0):INTEGER NOT NULL, 10)])
+        LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNoPullAggregateWithEmptyGroupSetOnPotentiallyEmptyInput">
+    <Resource name="sql">
+      <![CDATA[select g.emp_count, d.deptno
+from (select count(*) as emp_count from emp) g
+join (select deptno from dept where deptno = 10) d on true]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMP_COUNT=[$0], DEPTNO=[$1])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalAggregate(group=[{}], EMP_COUNT=[COUNT()])
+      LogicalProject($f0=[0])
+        LogicalTableScan(table=[[scott, EMP]])
+    LogicalProject(DEPTNO=[$0])
+      LogicalFilter(condition=[=(CAST($0):INTEGER NOT NULL, 10)])
+        LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testNoPullGroupByAboveNonEquiJoin">
     <Resource name="sql">
       <![CDATA[select g.deptno
@@ -48,6 +87,37 @@ LogicalProject(JOB=[$0], CNT=[$1])
       LogicalProject(JOB=[$2])
         LogicalTableScan(table=[[scott, EMP]])
     LogicalTableScan(table=[[scott, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPullAggregateWithEmptyGroupSetOnNonEmptyInput">
+    <Resource name="sql">
+      <![CDATA[select g.emp_count, d.deptno
+from (select count(*) as emp_count
+      from (values (1)) as v(n)) g
+join (select deptno from dept where deptno = 10) d on true]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(EMP_COUNT=[$0], DEPTNO=[$1])
+  LogicalJoin(condition=[true], joinType=[inner])
+    LogicalAggregate(group=[{}], EMP_COUNT=[COUNT()])
+      LogicalValues(tuples=[[{ 0 }]])
+    LogicalProject(DEPTNO=[$0])
+      LogicalFilter(condition=[=(CAST($0):INTEGER NOT NULL, 10)])
+        LogicalTableScan(table=[[scott, DEPT]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(EMP_COUNT=[$0], DEPTNO=[$1])
+  LogicalProject(EMP_COUNT=[$1], DEPTNO=[$0])
+    LogicalAggregate(group=[{1}], EMP_COUNT=[COUNT()])
+      LogicalJoin(condition=[true], joinType=[inner])
+        LogicalValues(tuples=[[{ 0 }]])
+        LogicalProject(DEPTNO=[$0])
+          LogicalFilter(condition=[=(CAST($0):INTEGER NOT NULL, 10)])
+            LogicalTableScan(table=[[scott, DEPT]])
 ]]>
     </Resource>
   </TestCase>

--- a/core/src/test/resources/sql/join-agg-transpose.iq
+++ b/core/src/test/resources/sql/join-agg-transpose.iq
@@ -75,4 +75,18 @@ EnumerableCalc(expr#0..3=[{inputs}], DEPTNO=[$t0], TOTAL_SAL=[$t3], DNAME=[$t2])
         EnumerableTableScan(table=[[scott, DEPT]])
 !plan
 
+# Tests that the rule preserves a row from an aggregate with an empty group set
+
+select g.emp_count, d.deptno
+from (select count(*) as emp_count from emp where false) g
+join (select deptno from dept where deptno = 10) d on true;
++-----------+--------+
+| EMP_COUNT | DEPTNO |
++-----------+--------+
+|         0 |     10 |
++-----------+--------+
+(1 row)
+
+!ok
+
 # End join-agg-transpose.iq


### PR DESCRIPTION


<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-7702](https://issues.apache.org/jira/projects/CALCITE/issues/CALCITE-7702)

## Changes Proposed
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.
-->
`JoinAggregateTransposeRule` can produce a non-equivalent plan when an Aggregate has an empty input and an empty group set. The original Aggregate returns one row, but after pull-up the JOIN columns become group keys and the new Aggregate returns no rows.

For an Aggregate with an empty group set, the rule now applies only when metadata proves that its input is non-empty. 
A regression test covers this case.