### PR TITLE
[CALCITE-7705] LISTAGG result type is never nullable

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlLibraryOperators.java
@@ -846,7 +846,7 @@ public abstract class SqlLibraryOperators {
   @LibraryOperator(libraries = {BIG_QUERY, POSTGRESQL}, exceptLibraries = {REDSHIFT})
   public static final SqlAggFunction STRING_AGG =
       SqlBasicAggFunction
-          .create(SqlKind.STRING_AGG, ReturnTypes.ARG0_NULLABLE,
+          .create(SqlKind.STRING_AGG, ReturnTypes.ARG0_NULLABLE_IF_EMPTY,
               OperandTypes.STRING.or(OperandTypes.STRING_STRING))
           .withFunctionType(SqlFunctionCategory.SYSTEM)
           .withSyntax(SqlSyntax.ORDERED_FUNCTION);
@@ -862,7 +862,7 @@ public abstract class SqlLibraryOperators {
       SqlBasicAggFunction
           .create(SqlKind.GROUP_CONCAT,
               ReturnTypes.andThen(ReturnTypes::stripOrderBy,
-                  ReturnTypes.ARG0_NULLABLE),
+                  ReturnTypes.ARG0_NULLABLE_IF_EMPTY),
               OperandTypes.STRING.or(OperandTypes.STRING_STRING))
           .withFunctionType(SqlFunctionCategory.SYSTEM)
           .withAllowsNullTreatment(false)

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlStdOperatorTable.java
@@ -2540,7 +2540,8 @@ public class SqlStdOperatorTable extends ReflectiveSqlOperatorTable {
    * The LISTAGG operator. String aggregator function.
    */
   public static final SqlAggFunction LISTAGG =
-      new SqlListaggAggFunction(SqlKind.LISTAGG, ReturnTypes.ARG0_NULLABLE);
+      new SqlListaggAggFunction(SqlKind.LISTAGG,
+          ReturnTypes.ARG0_NULLABLE_IF_EMPTY);
 
   /**
    * The FUSION operator. Multiset aggregator function.

--- a/core/src/test/resources/sql/agg.iq
+++ b/core/src/test/resources/sql/agg.iq
@@ -3380,6 +3380,30 @@ select listagg(ename) as combined_name from emp;
 
 !ok
 
+# [CALCITE-7705] LISTAGG result type is never nullable
+# Empty input yields NULL even though the argument is NOT NULL.
+select listagg(v, ',') as r from (values ('a')) as t(v) where false;
++---+
+| R |
++---+
+|   |
++---+
+(1 row)
+
+!ok
+
+# The IS NULL test must not be simplified away based on the result type.
+select r is null as n from (
+  select listagg(v, ',') as r from (values ('a')) as t(v) where false);
++------+
+| N    |
++------+
+| true |
++------+
+(1 row)
+
+!ok
+
 select listagg(ename) within group(order by gender, ename) as combined_name from emp;
 +-------------------------------------------------------+
 | COMBINED_NAME                                         |

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -12935,6 +12935,14 @@ public class SqlOperatorTest {
         false);
     f.checkAggType("listagg('test')", "CHAR(4) NOT NULL");
     f.checkAggType("listagg('test', ', ')", "CHAR(4) NOT NULL");
+    // Test case for [CALCITE-7705]
+    // LISTAGG result type is never nullable
+    // Nullable without GROUP BY even for a non-nullable argument, since the
+    // input may be empty
+    f.checkColumnType("select listagg('test') from (values (1))", "CHAR(4)");
+    // A FILTER clause may exclude all rows, so the result is nullable
+    f.checkColumnType("select listagg('test') filter (where x > 1) "
+        + "from (values (1)) as t(x) group by x", "CHAR(4)");
     final String[] values1 = {"'hello'", "CAST(null AS CHAR)", "'world'", "'!'"};
     f.checkAgg("listagg(x)", values1, isSingle("hello,world,!    "));
     final String[] values2 = {"0", "1", "2", "3"};
@@ -12950,6 +12958,10 @@ public class SqlOperatorTest {
 
   private static void checkStringAggFunc(SqlOperatorFixture f) {
     final String[] values = {"'x'", "null", "'yz'"};
+    // Test case for [CALCITE-7705]
+    // LISTAGG result type is never nullable
+    f.checkColumnType("select string_agg('x', ',') from (values (1))",
+        "CHAR(1)");
     f.checkAgg("string_agg(x)", values, isSingle("x ,yz"));
     f.checkAgg("string_agg(x,':')", values, isSingle("x :yz"));
     f.checkAgg("string_agg(x,':' order by x)", values, isSingle("x :yz"));
@@ -13008,6 +13020,9 @@ public class SqlOperatorTest {
 
   private static void checkGroupConcatFunc(SqlOperatorFixture f) {
     final String[] values = {"'x'", "null", "'yz'"};
+    // Test case for [CALCITE-7705]
+    // LISTAGG result type is never nullable
+    f.checkColumnType("select group_concat('x') from (values (1))", "CHAR(1)");
     f.checkAgg("group_concat(x)", values, isSingle("x ,yz"));
     f.checkAgg("group_concat(x,':')", values, isSingle("x :yz"));
     f.checkAgg("group_concat(x,':' order by x)", values, isSingle("x :yz"));


### PR DESCRIPTION
## Jira Link

[CALCITE-7705](https://issues.apache.org/jira/browse/CALCITE-7705)

## Changes Proposed

`LISTAGG` can sometimes return `NULL`, yet the type inference declared the type non-nullable.
This also fixes `STRING_AGG` and `GROUP_CONCAT` which have the same problem.