### PR TITLE
[CALCITE-7334] Compiling the generated Java code throws an exception …

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableMergeJoin.java
@@ -18,6 +18,7 @@ package org.apache.calcite.adapter.enumerable;
 
 import org.apache.calcite.adapter.java.JavaTypeFactory;
 import org.apache.calcite.linq4j.EnumerableDefaults;
+import org.apache.calcite.linq4j.function.Function1;
 import org.apache.calcite.linq4j.tree.BlockBuilder;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.linq4j.tree.Expressions;
@@ -530,9 +531,12 @@ public class EnumerableMergeJoin extends Join implements EnumerableRel {
                 Expressions.list(
                     leftExpression,
                     rightExpression,
-                    Expressions.lambda(
+                    // Force Function1: a single BOOLEAN key would otherwise
+                    // deduce Predicate1, which does not match the signature of
+                    // EnumerableDefaults.mergeJoin
+                    Expressions.lambda(Function1.class,
                         leftKeyPhysType.record(leftExpressions), left_),
-                    Expressions.lambda(
+                    Expressions.lambda(Function1.class,
                         rightKeyPhysType.record(rightExpressions), right_),
                     predicate,
                     EnumUtils.joinSelector(joinType,

--- a/core/src/test/resources/sql/sub-query.iq
+++ b/core/src/test/resources/sql/sub-query.iq
@@ -10151,4 +10151,39 @@ ORDER BY emp.ename;
 (8 rows)
 
 !ok
+
+!use scott
+
+# Test case for [CALCITE-7334] Compiling the generated Java code throws an exception when
+# a scalar sub-query is used in the SELECT list.
+# Result validated against PostgreSQL 14.
+select
+        (SELECT
+          COUNT(*)
+        FROM
+           "scott".emp
+        WHERE
+           v.empno >= 2), 3
+from "scott".emp as v;
++--------+--------+
+| EXPR$0 | EXPR$1 |
++--------+--------+
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
+|     14 |      3 |
++--------+--------+
+(14 rows)
+
+!ok
 # End sub-query.iq


### PR DESCRIPTION
…when a scalar subquery is used in the SELECT list

## Jira Link

[CALCITE-7334](https://issues.apache.org/jira/browse/CALCITE-7334)

## Changes Proposed

Fix incorrect Java code generated by specifying the type precisely