### PR TITLE
[CALCITE-7721] CAST of a ROW ARRAY element raises NullPointerException

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexToLixTranslator.java
@@ -361,6 +361,12 @@ public class RexToLixTranslator implements RexVisitor<RexToLixTranslator.Result>
       return Expressions.constant(null);
     }
     assert sourceType.getSqlTypeName() == SqlTypeName.ROW;
+    if (Types.getComponentType(operand.getType()) == null) {
+      // A ROW value is represented as an Object[] at runtime, but the
+      // expression that produces it may have type Object, for example an
+      // element of an array; the field access below requires an array.
+      operand = Expressions.convert_(operand, Object[].class);
+    }
     List<RelDataTypeField> targetTypes = targetType.getFieldList();
     List<RelDataTypeField> sourceTypes = sourceType.getFieldList();
     assert targetTypes.size() == sourceTypes.size();

--- a/core/src/test/resources/sql/struct.iq
+++ b/core/src/test/resources/sql/struct.iq
@@ -420,4 +420,39 @@ from (values (1)) as t2(x), (select ARRAY[ROW(ROW(1, 2), 3)] as arr) as t;
 
 !ok
 
+# [CALCITE-7721] CAST of a ROW ARRAY element raises NullPointerException.
+select cast(t.arr[1] as row(x integer, y integer)) as v
+from (select ARRAY[ROW(1, 2)] as arr) as t;
++--------+
+| V      |
++--------+
+| {1, 2} |
++--------+
+(1 row)
+
+!ok
+
+# The previous test using COALESCE, which casts both of its arguments to the
+# least restrictive type
+select coalesce(t.arr[1], ROW(9, 9)) as v from (select ARRAY[ROW(1, 2)] as arr) as t;
++--------+
+| V      |
++--------+
+| {1, 2} |
++--------+
+(1 row)
+
+!ok
+
+# COALESCE over a ROW
+select coalesce(t.r, ROW(9, 9)) as v from (select ROW(1, 2) as r) as t;
++--------+
+| V      |
++--------+
+| {1, 2} |
++--------+
+(1 row)
+
+!ok
+
 # End struct.iq


### PR DESCRIPTION
## Jira Link

[CALCITE-7721](https://issues.apache.org/jira/browse/CALCITE-7721)

## Changes Proposed

Another small fix in the Java code generated for handling ROW types at runtime.