### PR TITLE
[CALCITE-7724] SqlUtil#lookupSubjectRoutines rejects a valid operator…

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -519,12 +519,8 @@ public abstract class SqlUtil {
 
   private static Iterator<SqlOperator> filterOperatorRoutinesByKind(
       Iterator<SqlOperator> routines, final SqlKind sqlKind) {
-    // Map both sides through getFunctionKind() so a candidate can still match a call
-    // that is already bound to that very candidate (or an operator with the same
-    // requested kind) even when getFunctionKind() maps that kind to something else,
-    // e.g. SqlKind.POSITION/CHAR_LENGTH both map to OTHER_FUNCTION. Comparing the
-    // candidate's mapped kind against the call's raw, unmapped kind is asymmetric and
-    // can spuriously reject every candidate, including the operator being called.
+    // Mirror getFunctionKind() on both sides, or an operator whose kind maps to
+    // something else (e.g. POSITION -> OTHER_FUNCTION) can fail to match itself.
     final SqlKind sqlFunctionKind = sqlKind.getFunctionKind();
     return Iterators.filter(routines,
         operator -> requireNonNull(operator, "operator")

--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -519,9 +519,16 @@ public abstract class SqlUtil {
 
   private static Iterator<SqlOperator> filterOperatorRoutinesByKind(
       Iterator<SqlOperator> routines, final SqlKind sqlKind) {
+    // Map both sides through getFunctionKind() so a candidate can still match a call
+    // that is already bound to that very candidate (or an operator with the same
+    // requested kind) even when getFunctionKind() maps that kind to something else,
+    // e.g. SqlKind.POSITION/CHAR_LENGTH both map to OTHER_FUNCTION. Comparing the
+    // candidate's mapped kind against the call's raw, unmapped kind is asymmetric and
+    // can spuriously reject every candidate, including the operator being called.
+    final SqlKind sqlFunctionKind = sqlKind.getFunctionKind();
     return Iterators.filter(routines,
         operator -> requireNonNull(operator, "operator")
-            .getKind().getFunctionKind() == sqlKind);
+            .getKind().getFunctionKind() == sqlFunctionKind);
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1025,6 +1025,43 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .fails("Parameters must be of the same type");
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7724">
+   * [CALCITE-7724] SqlUtil#lookupSubjectRoutines rejects a valid operator when two
+   * operator-table entries resolve to the same operator and that operator's
+   * {@link SqlKind} is remapped by {@link SqlKind#getFunctionKind()}</a>.
+   *
+   * <p>{@link SqlUtil#lookupSubjectRoutines} only reaches its "fourth pass"
+   * ({@code filterOperatorRoutinesByKind}) once at least two candidate operators survive
+   * the earlier passes - which happens whenever an operator table (or a chain of them)
+   * contains more than one entry for the same operator name, arity and category, e.g.
+   * because it is registered in two different operator tables that get chained together.
+   * That pass compares {@code candidate.getKind().getFunctionKind()} (mapped) against the
+   * call's already-bound, unmapped {@code SqlKind} - for any {@link SqlKind} that
+   * {@code getFunctionKind()} maps to something else (such as {@link SqlKind#POSITION} or
+   * the now-dedicated {@link SqlKind#CHAR_LENGTH}, both mapped to
+   * {@link SqlKind#OTHER_FUNCTION}), this comparison fails even when the candidate is the
+   * operator the call is already bound to - eliminating every candidate and causing a
+   * spurious "No match found for function signature" validation error for an otherwise
+   * perfectly valid call. */
+  @Test void testFunctionKindMismatchWithDuplicateOperatorTableEntry() {
+    // Chaining the standard operator table with itself is a minimal way to force two
+    // candidates for the same operator to reach the fourth pass; in practice this also
+    // happens with any two chained operator tables that both contribute an entry for the
+    // same builtin operator (which is how this was found - via a composite operator table
+    // with more than one contributor).
+    final SqlOperatorTable duplicated =
+        SqlOperatorTables.chain(SqlStdOperatorTable.instance(), SqlStdOperatorTable.instance());
+    expr("position('mouse' in 'house')")
+        .withOperatorTable(duplicated)
+        .ok();
+    expr("char_length('string')")
+        .withOperatorTable(duplicated)
+        .ok();
+    expr("character_length('string')")
+        .withOperatorTable(duplicated)
+        .ok();
+  }
+
   @Test void testTrim() {
     expr("trim('mustache' FROM 'beard')").ok();
     expr("trim(both 'mustache' FROM 'beard')").ok();

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -1026,29 +1026,16 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7724">
-   * [CALCITE-7724] SqlUtil#lookupSubjectRoutines rejects a valid operator when two
-   * operator-table entries resolve to the same operator and that operator's
-   * {@link SqlKind} is remapped by {@link SqlKind#getFunctionKind()}</a>.
+   * [CALCITE-7724] SqlUtil#lookupSubjectRoutines rejects a valid operator when its
+   * SqlKind is remapped by SqlKind#getFunctionKind() and two operator-table entries
+   * resolve to it</a>.
    *
-   * <p>{@link SqlUtil#lookupSubjectRoutines} only reaches its "fourth pass"
-   * ({@code filterOperatorRoutinesByKind}) once at least two candidate operators survive
-   * the earlier passes - which happens whenever an operator table (or a chain of them)
-   * contains more than one entry for the same operator name, arity and category, e.g.
-   * because it is registered in two different operator tables that get chained together.
-   * That pass compares {@code candidate.getKind().getFunctionKind()} (mapped) against the
-   * call's already-bound, unmapped {@code SqlKind} - for any {@link SqlKind} that
-   * {@code getFunctionKind()} maps to something else (such as {@link SqlKind#POSITION} or
-   * the now-dedicated {@link SqlKind#CHAR_LENGTH}, both mapped to
-   * {@link SqlKind#OTHER_FUNCTION}), this comparison fails even when the candidate is the
-   * operator the call is already bound to - eliminating every candidate and causing a
-   * spurious "No match found for function signature" validation error for an otherwise
-   * perfectly valid call. */
+   * <p>The kind-based fourth pass in {@code filterOperatorRoutinesByKind} maps only
+   * the candidate's kind through {@code getFunctionKind()}, not the call's own kind -
+   * so an operator whose kind is remapped (e.g. {@link SqlKind#POSITION}) can fail to
+   * match itself once a second candidate for the same name exists. */
   @Test void testFunctionKindMismatchWithDuplicateOperatorTableEntry() {
-    // Chaining the standard operator table with itself is a minimal way to force two
-    // candidates for the same operator to reach the fourth pass; in practice this also
-    // happens with any two chained operator tables that both contribute an entry for the
-    // same builtin operator (which is how this was found - via a composite operator table
-    // with more than one contributor).
+    // Chaining the operator table with itself ensures that each appears twice.
     final SqlOperatorTable duplicated =
         SqlOperatorTables.chain(SqlStdOperatorTable.instance(), SqlStdOperatorTable.instance());
     expr("position('mouse' in 'house')")


### PR DESCRIPTION
… when getFunctionKind() remaps its kind and 2+ candidates share a name

filterOperatorRoutinesByKind's "fourth pass" only runs once at least two candidates survive the earlier passes (a single surviving candidate short-circuits before this pass). It compares candidate.getKind().getFunctionKind() against the call's own, already-bound SqlKind - but that comparison applies getFunctionKind()'s remapping (introduced for this method) to the candidate side only, not to the requested side.

For any SqlKind that getFunctionKind() maps to something else - POSITION and the newly-dedicated CHAR_LENGTH both map to OTHER_FUNCTION, along with ~90 others in that switch - this asymmetry means an operator can fail to match even itself, once a second candidate for the same name is present (e.g. because two chained operator tables both contribute an entry for it). The call is rejected outright with "No match found for function signature ...", even though exactly the intended operator was available.

## Jira Link

[CALCITE-7724](https://issues.apache.org/jira/browse/CALCITE-7724)

## Changes Proposed
<!--
Fix: map both sides of the comparison through getFunctionKind() before comparing, matching normal-case comparisons for kinds it doesn't remap.

Added a regression test (chaining the standard operator table with itself to force the two-candidate precondition, the minimal way to reach the buggy pass) and verified the entire SqlValidatorTest suite (589 tests) still passes with the fix.
-->
