### PR TITLE
[CALCITE-7725] Review safety of checked arithmetic operators

### DIFF
--- a/core/src/main/java/org/apache/calcite/prepare/Prepare.java
+++ b/core/src/main/java/org/apache/calcite/prepare/Prepare.java
@@ -260,6 +260,12 @@ public abstract class Prepare {
     // Convert some operations to use checked arithmetic:
     // - all arithmetic operations on exact types if the conformance requires checked arithmetic
     // - all arithmetic that produces INTERVAL results, regardless of the conformance
+    //
+    // SqlToRelConverter already runs ConvertToChecked. This second conversion is needed for:
+    // - INTERVAL arithmetic under a conformance without checked
+    //   arithmetic (SqlToRelConverter installs no converter at all)
+    // - expressions that SqlToRelConverter does not build through
+    //   Blackboard#convertExpression
     ConvertToChecked checkedConv =
         new ConvertToChecked(root.rel.getCluster().getRexBuilder(), convertToChecked);
     RelNode rel = checkedConv.visit(root.rel);

--- a/core/src/main/java/org/apache/calcite/rex/RexAnalyzer.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexAnalyzer.java
@@ -19,6 +19,7 @@ package org.apache.calcite.rex;
 import org.apache.calcite.linq4j.Linq4j;
 import org.apache.calcite.plan.RelOptPredicateList;
 import org.apache.calcite.rel.metadata.NullSentinel;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Pair;
 import org.apache.calcite.util.Util;
@@ -136,6 +137,12 @@ public class RexAnalyzer {
     }
 
     @Override public Void visitCall(RexCall call) {
+      if (SqlKind.CHECKED_ARITHMETIC.contains(call.getKind())) {
+        // RexInterpreter computes with unbounded values, so it cannot tell
+        // whether checked arithmetic overflows
+        ++unsupportedCount;
+        return null;
+      }
       switch (call.getKind()) {
       case CAST:
       case M2V:

--- a/core/src/main/java/org/apache/calcite/rex/RexCall.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexCall.java
@@ -222,12 +222,15 @@ public class RexCall extends RexNode {
     // Only boolean-valued calls can be always-true; e.g. CAST(TRUE AS INTEGER)
     // evaluates to 1 (INTEGER), not a boolean, even though its operand is
     // always true.
+    // An expression that may throw is never always-true: "1 / 0 IS NOT NULL"
+    // raises an error rather than returning TRUE.
     if (getType().getSqlTypeName() != SqlTypeName.BOOLEAN) {
       return false;
     }
     switch (getKind()) {
     case IS_NOT_NULL:
-      return !operands.get(0).getType().isNullable();
+      return !operands.get(0).getType().isNullable()
+          && RexSimplify.isSafeExpression(operands.get(0));
     case IS_NOT_TRUE:
     case IS_FALSE:
     case NOT:
@@ -240,7 +243,8 @@ public class RexCall extends RexNode {
       final Sarg<?> sarg = ((RexLiteral) operands.get(1)).getValueAs(Sarg.class);
       return requireNonNull(sarg, "sarg").isAll()
           && (sarg.nullAs == RexUnknownAs.TRUE
-              || !operands.get(0).getType().isNullable());
+              || !operands.get(0).getType().isNullable())
+          && RexSimplify.isSafeExpression(operands.get(0));
     default:
       return false;
     }
@@ -253,7 +257,8 @@ public class RexCall extends RexNode {
     }
     switch (getKind()) {
     case IS_NULL:
-      return !operands.get(0).getType().isNullable();
+      return !operands.get(0).getType().isNullable()
+          && RexSimplify.isSafeExpression(operands.get(0));
     case IS_NOT_TRUE:
     case IS_FALSE:
     case NOT:
@@ -266,7 +271,8 @@ public class RexCall extends RexNode {
       final Sarg<?> sarg = ((RexLiteral) operands.get(1)).getValueAs(Sarg.class);
       return requireNonNull(sarg, "sarg").isNone()
           && (sarg.nullAs == RexUnknownAs.FALSE
-              || !operands.get(0).getType().isNullable());
+              || !operands.get(0).getType().isNullable())
+          && RexSimplify.isSafeExpression(operands.get(0));
     default:
       return false;
     }

--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -1034,8 +1034,11 @@ public class RexSimplify {
 
   private RexNode simplifyUnaryMinus(RexCall call, RexUnknownAs unknownAs) {
     final RexNode a = call.getOperands().get(0);
-    if (a.getKind() == SqlKind.MINUS_PREFIX) {
-      // -(-(x)) ==> x
+    if (call.getKind() == SqlKind.MINUS_PREFIX
+        && a.getKind() == SqlKind.MINUS_PREFIX) {
+      // -(-(x)) ==> x.
+      // Not valid for checked arithmetic, where negation of the minimum value
+      // of the type throws.
       return simplify(((RexCall) a).getOperands().get(0), unknownAs);
     }
     return simplifyGenericNode(call);
@@ -1548,13 +1551,9 @@ public class RexSimplify {
       safeOps.add(SqlKind.ARRAY_VALUE_CONSTRUCTOR);
       safeOps.add(SqlKind.PLUS_PREFIX);
       safeOps.add(SqlKind.MINUS_PREFIX);
-      safeOps.add(SqlKind.CHECKED_MINUS_PREFIX);
       safeOps.add(SqlKind.PLUS);
       safeOps.add(SqlKind.MINUS);
       safeOps.add(SqlKind.TIMES);
-      safeOps.add(SqlKind.CHECKED_PLUS);
-      safeOps.add(SqlKind.CHECKED_MINUS);
-      safeOps.add(SqlKind.CHECKED_TIMES);
       safeOps.add(SqlKind.IS_FALSE);
       safeOps.add(SqlKind.IS_NOT_FALSE);
       safeOps.add(SqlKind.IS_TRUE);
@@ -1598,6 +1597,13 @@ public class RexSimplify {
     @Override public Boolean visitCall(RexCall call) {
       SqlKind sqlKind = call.getKind();
       SqlOperator sqlOperator = call.getOperator();
+
+      if (SqlKind.CHECKED_ARITHMETIC.contains(sqlKind)) {
+        // Checked arithmetic throws on overflow, so it is only safe when the
+        // arithmetic is never performed, i.e. when an operand is NULL.
+        return RexVisitorImpl.visitArrayAnd(this, call.operands)
+            && call.operands.stream().anyMatch(o -> RexUtil.isNullLiteral(o, true));
+      }
 
       switch (sqlKind) {
       case DIVIDE:
@@ -1683,6 +1689,8 @@ public class RexSimplify {
   *
   * <p>Division is an unsafe operator; consider the following:
   * <pre>case when a &gt; 0 then 1 / a else null end</pre>
+  *
+  * <p>Checked arithmetic is unsafe too, because it throws on overflow
   */
   static boolean isSafeExpression(RexNode r) {
     return r.accept(SafeRexVisitor.INSTANCE);

--- a/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/SqlToRelConverter.java
@@ -291,6 +291,9 @@ public class SqlToRelConverter {
   private int explainParamCount;
   public final SqlToRelConverter.Config config;
   private final RelBuilder relBuilder;
+  /** Rewrites arithmetic into checked arithmetic; null if the conformance
+   * does not require checked arithmetic. */
+  private final @Nullable RexShuttle checkedConverter;
 
   /**
    * Fields used in name resolution for correlated sub-queries.
@@ -377,6 +380,13 @@ public class SqlToRelConverter {
             config.getRelBuilderFactory().create(cluster,
              validator != null ? validator.getCatalogReader().unwrap(RelOptSchema.class) : null)
         .transform(config.getRelBuilderConfigTransform());
+    // Simplification assumes that arithmetic never throws, which is wrong for
+    // checked arithmetic; so every expression is converted to checked
+    // arithmetic as soon as it is built, before anything can simplify it
+    this.checkedConverter =
+        validator != null && validator.config().conformance().checkedArithmetic()
+            ? new ConvertToChecked(rexBuilder, true).converter
+            : null;
     this.hintStrategies = config.getHintStrategyTable();
 
     cluster.setHintStrategies(this.hintStrategies);
@@ -5938,6 +5948,12 @@ public class SqlToRelConverter {
     }
 
     @Override public RexNode convertExpression(SqlNode expr) {
+      final RexNode rex = convertExpression0(expr);
+      // Convert arithmetic to checked arithmetic if needed
+      return checkedConverter == null ? rex : rex.accept(checkedConverter);
+    }
+
+    private RexNode convertExpression0(SqlNode expr) {
       // If we're in aggregation mode and this is an expression in the
       // GROUP BY clause, return a reference to the field.
       AggConverter agg = this.agg;

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -4788,6 +4788,30 @@ class RexProgramTest extends RexProgramTestBase {
     checkSimplify(add(zero, sub(nullInt, nullInt)), "null:INTEGER");
   }
 
+  /** Unit test for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7725">[CALCITE-7725]
+   * Review safety of checked arithmetic operators</a>. */
+  @Test void testSimplifyCheckedArithmetic() {
+    final RexNode a = vIntNotNull(1);
+    final RexNode b = vIntNotNull(2);
+    final RexNode checkedMul =
+        rexBuilder.makeCall(SqlStdOperatorTable.CHECKED_MULTIPLY, a, b);
+
+    // Unchecked arithmetic wraps around, so it never throws
+    checkSimplify(isNotNull(mul(a, b)), "true");
+    checkSimplify(add(mul(a, b), nullInt), "null:INTEGER");
+
+    // Checked arithmetic throws on overflow
+    checkSimplifyUnchanged(isNotNull(checkedMul));
+    checkSimplifyUnchanged(
+        rexBuilder.makeCall(SqlStdOperatorTable.CHECKED_PLUS, checkedMul, nullInt));
+
+    // A checked operation with a NULL operand is never performed, hence safe
+    checkSimplify(
+        rexBuilder.makeCall(SqlStdOperatorTable.CHECKED_PLUS, a, nullInt),
+        "null:INTEGER");
+  }
+
   @Test void testSimplifyCastWithConstantReduction() {
     RexNode dateStr = literal("2020-10-30");
     RelDataType nullableDateType =

--- a/core/src/test/resources/sql/cast.iq
+++ b/core/src/test/resources/sql/cast.iq
@@ -65,6 +65,31 @@ select 2147483647 * 2147483647;
 Caused by: java.lang.ArithmeticException
 !error
 
+# Test cases for [CALCITE-7725] Review safety of checked arithmetic operators
+# https://issues.apache.org/jira/browse/CALCITE-7725
+
+# A checked operation with a NULL operand is never performed, so the whole
+# expression can still be simplified to NULL
+select cast(null as integer) + empno as c from emp where empno = 7369;
++---+
+| C |
++---+
+|   |
++---+
+(1 row)
+
+!ok
+
+# "empno * 100000000" overflows, so "IS NOT NULL" must not become TRUE
+select empno from emp where empno = 7369 and empno * 100000000 is not null;
+integer overflow
+!error
+
+# and "x + NULL" must not become NULL without computing x
+select empno * 100000000 + cast(null as integer) as c from emp where empno = 7369;
+integer overflow
+!error
+
 !use scott
 
 # Cast a character literal to a timestamp; note: the plan does not contain CAST


### PR DESCRIPTION
## Jira Link

[CALCITE-7725](https://issues.apache.org/jira/browse/CALCITE-7725)

## Changes Proposed

Checked arithmetic is marked as non-safe, since such operators can always throw.

There's a visitor ConvertToChecked which converts unchecked arithmetic to checked arithmetic based on conformance. This was run in Prepare on the Rel representation. Turns out that SqlToRelConverter invokes `simplify` which makes some arithmetic simplifications which happen BEFORE this conversion. So I had to add a second invocation of this pass inside SqlToRelConverter, driven by the same conformance flag. (Both are necessary in general.)