### PR TITLE
[CALCITE-6087] EnumerableSortedAggregate returns incorrect result when input is empty

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableSortedAggregateRule.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableSortedAggregateRule.java
@@ -47,7 +47,7 @@ class EnumerableSortedAggregateRule extends ConverterRule {
 
   @Override public @Nullable RelNode convert(RelNode rel) {
     final Aggregate agg = (Aggregate) rel;
-    if (!Aggregate.isSimple(agg)) {
+    if (!Aggregate.isSimple(agg) || agg.getGroupSet().isEmpty()) {
       return null;
     }
     final RelTraitSet inputTraits = rel.getCluster()

--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableSortedAggregateTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableSortedAggregateTest.java
@@ -50,6 +50,30 @@ public class EnumerableSortedAggregateTest {
             "deptno=20; max_salary=8000.0; num_employee=1");
   }
 
+  @Test void aggOnEmptyInput() {
+    tester(false, new HrSchema())
+        .query("select max(deptno) as m, count(*) as c "
+            + "from emps where deptno > 100")
+        .explainContains(
+            "EnumerableAggregate(group=[{}], m=[MAX($1)], c=[COUNT()])\n"
+                + "  EnumerableCalc")
+        .returnsOrdered("m=null; c=0");
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6087">[CALCITE-6087]
+   * EnumerableSortedAggregate returns incorrect result when input is empty</a>. */
+  @Test void sortedAggRuleRejectsEmptyGroupSet() {
+    tester(false, new HrSchema())
+        .query("select max(deptno) as m, count(*) as c "
+            + "from emps where deptno > 100")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner -> {
+          planner.removeRule(EnumerableRules.ENUMERABLE_AGGREGATE_RULE);
+          planner.addRule(EnumerableRules.ENUMERABLE_SORTED_AGGREGATE_RULE);
+        })
+        .throws_("There are not enough rules to produce a node with desired properties");
+  }
+
   @Test void sortedAggTwoGroupKeys() {
     tester(false, new HrSchema())
         .query(


### PR DESCRIPTION
## Jira Link

[CALCITE-6087](https://issues.apache.org/jira/browse/CALCITE-6087)

## Changes Proposed

When a query applies `MAX` or `COUNT` to empty input, a sorted global aggregate returns no row. SQL requires one row containing `NULL` and `0`.

Sorted grouping emits one row per observed key, but a global aggregate has no grouping key. The sorted aggregate rule now declines an empty group set, so `EnumerableAggregate` handles it through its zero-key singleton path. Grouped sorted aggregates are unchanged.

## Testing

| Scenario | Result |
| --- | --- |
| Forced sorted execution before the fix | Empty result instead of `m=null; c=0` |
| Standard aggregate after the fix | `m=null; c=0` |
| Sorted-only planning after the fix | Expected planning failure |

<details>
<summary>Raw logs</summary>

With the pre-fix parent version of `EnumerableSortedAggregateRule`:

```text
$ JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :core:test --tests org.apache.calcite.test.enumerable.EnumerableSortedAggregateTest.sortedAggOnEmptyInput --no-daemon --console=plain
Expected: "m=null; c=0"
     but: was ""
1 test completed, 1 failed
BUILD FAILED

$ JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :core:test --tests 'org.apache.calcite.test.enumerable.EnumerableSortedAggregateTest.aggOnEmptyInput' --tests 'org.apache.calcite.test.enumerable.EnumerableSortedAggregateTest.sortedAggRuleRejectsEmptyGroupSet' --no-daemon --console=plain --rerun-tasks
Expected: a string containing "There are not enough rules to produce a node with desired properties"
     but: was "org.opentest4j.AssertionFailedError: expected exception but none was thrown"
2 tests completed, 1 failed
BUILD FAILED
```

With this PR, the standard-path assertion observed `m=null; c=0`:

```text
$ JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :core:test --tests 'org.apache.calcite.test.enumerable.EnumerableSortedAggregateTest.aggOnEmptyInput' --tests 'org.apache.calcite.test.enumerable.EnumerableSortedAggregateTest.sortedAggRuleRejectsEmptyGroupSet' --no-daemon --console=plain --rerun-tasks
2 completed, 0 failed, 0 skipped
BUILD SUCCESSFUL

$ JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :core:test --tests 'org.apache.calcite.test.enumerable.EnumerableSortedAggregateTest' --no-daemon --console=plain
13 completed, 0 failed, 0 skipped
BUILD SUCCESSFUL
```

</details>