### PR TITLE
[CALCITE-7667] Improve string-literal encoding in pushdown translators (follow-up)

### DIFF
--- a/pig/src/main/java/org/apache/calcite/adapter/pig/PigFilter.java
+++ b/pig/src/main/java/org/apache/calcite/adapter/pig/PigFilter.java
@@ -135,9 +135,12 @@ public class PigFilter extends Filter implements PigRel {
    * Converts a literal to a Pig Latin string literal.
    */
   private static String getLiteralAsString(RexLiteral literal) {
-    // Pig Latin string literals use `''` to represent a single `'` inside
-    // a `'...'` literal, so double any embedded `'` before wrapping
     final String raw = RexLiteral.stringValue(literal);
-    return '\'' + (raw != null ? raw.replace("'", "''") : null) + '\'';
+    // Escape before wrapping
+    return '\''
+        + (raw != null
+            ? raw.replace("\\", "\\\\").replace("'", "\\'")
+            : null)
+        + '\'';
   }
 }

--- a/pig/src/test/java/org/apache/calcite/adapter/pig/PigFilterLiteralEscapeTest.java
+++ b/pig/src/test/java/org/apache/calcite/adapter/pig/PigFilterLiteralEscapeTest.java
@@ -57,20 +57,32 @@ class PigFilterLiteralEscapeTest {
     assertThat(call(charLiteral("alice")), is("'alice'"));
   }
 
+  @Test void valueWithBackslash() throws Throwable {
+    assertThat(call(charLiteral("a\\b")), is("'a\\\\b'"));
+  }
+
+  @Test void valueWithBackslashBeforeApostrophe() throws Throwable {
+    assertThat(call(charLiteral("a\\'b")), is("'a\\\\\\'b'"));
+  }
+
+  @Test void valueWithTrailingBackslash() throws Throwable {
+    assertThat(call(charLiteral("a\\")), is("'a\\\\'"));
+  }
+
   @Test void valueWithApostrophe() throws Throwable {
-    assertThat(call(charLiteral("O'Brien")), is("'O''Brien'"));
+    assertThat(call(charLiteral("O'Brien")), is("'O\\'Brien'"));
   }
 
   @Test void valueWithApostropheAtTheEnd() throws Throwable {
-    assertThat(call(charLiteral("a'")), is("'a'''"));
+    assertThat(call(charLiteral("a'")), is("'a\\''"));
   }
 
   @Test void valueWithApostropheAtTheStart() throws Throwable {
-    assertThat(call(charLiteral("'a")), is("'''a'"));
+    assertThat(call(charLiteral("'a")), is("'\\'a'"));
   }
 
   @Test void valueWithMultipleApostrophes() throws Throwable {
-    assertThat(call(charLiteral("a''b")), is("'a''''b'"));
+    assertThat(call(charLiteral("a''b")), is("'a\\'\\'b'"));
   }
 
   @Test void emptyValue() throws Throwable {

--- a/pig/src/test/java/org/apache/calcite/test/PigAdapterTest.java
+++ b/pig/src/test/java/org/apache/calcite/test/PigAdapterTest.java
@@ -58,9 +58,9 @@ class PigAdapterTest extends AbstractPigTest {
   }
 
   @Test void testFilterWithSingleQuote() {
-    // A string literal containing a single quote must be doubled per Pig Latin
+    // A string literal containing a single quote must be escaped per Pig Latin
     // string-literal rules so it does not break out of the '...' literal in
-    // the generated FILTER statement.
+    // the generated FILTER statement. Verified against pig.
     CalciteAssert.that()
         .with(MODEL)
         .query("select * from \"t\" where \"tc0\" = 'a''b'")
@@ -69,7 +69,7 @@ class PigAdapterTest extends AbstractPigTest {
             pigScriptChecker("t = LOAD '"
                 + getFullPathForTestDataFile("data.txt")
                 + "' USING PigStorage() AS (tc0:chararray, tc1:chararray);\n"
-                + "t = FILTER t BY (tc0 == 'a''b');"));
+                + "t = FILTER t BY (tc0 == 'a\\'b');"));
   }
 
   @Test void testImplWithMultipleFilters() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-7667](https://issues.apache.org/jira/browse/CALCITE-7667)

## Changes Proposed
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.
-->
The original patch for this ticket ([fbfdf89](https://github.com/apache/calcite/commit/fbfdf89206a9c65f64355e6fdeac05f025a471dd)) considered that PigLatin escapes a single quote by doubling it (as SQL does); however this is incorrect, it is escaped by using backslash (PigLatin uses backslash as escape character, see https://pig.apache.org/docs/r0.16.0/cont.html).

The current follow-up patch corrects this, and adjusts the corresponding tests.