### PR TITLE
[CALCITE-7731] Bound plain-notation expansion of DECIMAL literals to prevent parse-time OutOfMemoryError

### DIFF
--- a/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
+++ b/core/src/main/java/org/apache/calcite/config/CalciteSystemProperty.java
@@ -492,6 +492,22 @@ public final class CalciteSystemProperty<T> {
   public static final CalciteSystemProperty<String> MODEL_CLASSES_DENIED =
       stringProperty("calcite.model.classes.denied", "");
 
+  /**
+   * Maximum number of decimal digits that the plain-notation expansion of a {@code DECIMAL}
+   * literal may contain.
+   *
+   * <p>{@link java.math.BigDecimal} accepts any {@code int} exponent, so without a bound
+   * a ~15-character literal such as {@code DECIMAL '1E2147483647'} would ask
+   * {@link java.math.BigDecimal#toPlainString()} to materialize one character per digit,
+   * i.e. a multi-gigabyte allocation that would end in {@link OutOfMemoryError} inside the parser.
+   *
+   * <p>Default {@code 10000} is well beyond any dialect's realistic maximum {@code DECIMAL}
+   * precision while still bounding worst-case allocation to ~20 KB. Raise if a dialect
+   * legitimately needs more.
+   */
+  public static final CalciteSystemProperty<Integer> MAX_DECIMAL_LITERAL_PLAIN_DIGITS =
+      intProperty("calcite.parser.maxDecimalLiteralPlainDigits", 10_000, v -> v > 0);
+
   private static CalciteSystemProperty<Boolean> booleanProperty(String key,
       boolean defaultValue) {
     // Note that "" -> true (convenient for command-lines flags like '-Dflag')

--- a/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
+++ b/core/src/main/java/org/apache/calcite/rel/rel2sql/SqlImplementor.java
@@ -1758,8 +1758,12 @@ public abstract class SqlImplementor {
         }
         return SqlLiteral.createApproxNumeric(d.toString(), POS);
       } else {
-        return SqlLiteral.createExactNumeric(
-            castNonNull(literal.getValueAs(BigDecimal.class)).toPlainString(), POS);
+        final BigDecimal bd = castNonNull(literal.getValueAs(BigDecimal.class));
+        if (!SqlUtil.isBoundedDecimal(bd)) {
+          throw new IllegalStateException(
+              "DECIMAL literal exceeds the configured plain-notation bound: " + bd);
+        }
+        return SqlLiteral.createExactNumeric(bd.toPlainString(), POS);
       }
     }
     case APPROXIMATE_NUMERIC:

--- a/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexBuilder.java
@@ -1549,6 +1549,10 @@ public class RexBuilder {
       } else if (type.getScale() != RelDataType.SCALE_NOT_SPECIFIED) {
         o = ((BigDecimal) o).setScale(type.getScale(), typeFactory.getTypeSystem().roundingMode());
         if (type.getScale() < 0) {
+          if (!SqlUtil.isBoundedDecimal((BigDecimal) o)) {
+            throw new IllegalArgumentException("Cannot convert " + o + " to " + type
+                + ": plain-notation expansion exceeds the configured bound");
+          }
           o = new BigDecimal(((BigDecimal) o).toPlainString());
         }
       }

--- a/core/src/main/java/org/apache/calcite/sql/SqlNumericLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlNumericLiteral.java
@@ -90,6 +90,10 @@ public class SqlNumericLiteral extends SqlLiteral {
   @Override public String toValue() {
     final BigDecimal bd = getValueNonNull();
     if (exact) {
+      if (!SqlUtil.isBoundedDecimal(bd)) {
+        throw new IllegalArgumentException("DECIMAL literal '" + bd
+            + "' exceeds the configured plain-notation bound");
+      }
       return bd.toPlainString();
     }
     return Util.toScientificNotation(bd);

--- a/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUtil.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.sql;
 
 import org.apache.calcite.avatica.util.ByteString;
+import org.apache.calcite.config.CalciteSystemProperty;
 import org.apache.calcite.linq4j.Ord;
 import org.apache.calcite.linq4j.function.Functions;
 import org.apache.calcite.rel.RelNode;
@@ -58,6 +59,7 @@ import com.google.common.collect.Lists;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.checker.nullness.qual.PolyNull;
 
+import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
@@ -960,6 +962,18 @@ public abstract class SqlUtil {
     }
 
     return ret.toString();
+  }
+
+  /**
+   * Returns whether {@code value}'s plain-notation expansion fits within
+   * the configured bound
+   * ({@link CalciteSystemProperty#MAX_DECIMAL_LITERAL_PLAIN_DIGITS}).
+   * Callers that are about to feed {@code value} to {@code toPlainString}
+   * (or the equivalent) must gate on this method first.
+   */
+  public static boolean isBoundedDecimal(BigDecimal value) {
+    final long limit = CalciteSystemProperty.MAX_DECIMAL_LITERAL_PLAIN_DIGITS.value();
+    return (long) value.precision() + Math.abs((long) value.scale()) <= limit;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
+++ b/core/src/main/java/org/apache/calcite/sql/parser/SqlParserUtil.java
@@ -338,15 +338,18 @@ public final class SqlParserUtil {
   }
 
   public static SqlNumericLiteral parseDecimalLiteral(String s, SqlParserPos pos) {
+    final BigDecimal value;
     try {
-      // The s maybe scientific notation string,e.g. 1.2E-3,
-      // we need to convert it to 0.0012
-      s = new BigDecimal(s).toPlainString();
+      value = new BigDecimal(s);
     } catch (NumberFormatException e) {
       throw SqlUtil.newContextException(pos,
           RESOURCE.invalidLiteral(s, "DECIMAL"));
     }
-    return SqlLiteral.createExactNumeric(s, pos);
+    if (!SqlUtil.isBoundedDecimal(value)) {
+      throw SqlUtil.newContextException(pos,
+          RESOURCE.invalidLiteral(s, "DECIMAL"));
+    }
+    return SqlLiteral.createExactNumeric(value.toPlainString(), pos);
   }
 
   public static SqlTimeLiteral parseTimeLiteral(String s, SqlParserPos pos) {

--- a/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
+++ b/testkit/src/main/java/org/apache/calcite/sql/parser/SqlParserTest.java
@@ -1056,6 +1056,25 @@ public class SqlParserTest {
         .ok("SELECT 999");
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7731">[CALCITE-7731]
+   * Bound plain-notation expansion of DECIMAL literals to prevent parse-time
+   * OutOfMemoryError</a>. */
+  @Test void testDecimalLiteralWithOutOfRangeExponent() {
+    sql("select DECIMAL ^'1E2147483647'^")
+        .fails("(?s)Literal '1E2147483647' can not be parsed to type 'DECIMAL'.*");
+    sql("select DECIMAL ^'1E-2147483647'^")
+        .fails("(?s)Literal '1E-2147483647' can not be parsed to type 'DECIMAL'.*");
+    sql("select DECIMAL ^'1E1000000000'^")
+        .fails("(?s)Literal '1E1000000000' can not be parsed to type 'DECIMAL'.*");
+    sql("select DECIMAL ^'-9.9E999999999'^")
+        .fails("(?s)Literal '-9.9E999999999' can not be parsed to type 'DECIMAL'.*");
+    // Exponents within the bound still expand to plain notation.
+    sql("select DECIMAL '1E10'")
+        .ok("SELECT 10000000000");
+    sql("select DECIMAL '1E-10'")
+        .ok("SELECT 0.0000000001");
+  }
+
   @Test void testDecimalWithScale() {
     sql("select cast(15 as decimal(3, 1))")
         .ok("SELECT CAST(15 AS DECIMAL(3, 1))");


### PR DESCRIPTION
<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-7731](https://issues.apache.org/jira/browse/CALCITE-7731)

## Changes Proposed
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.
-->
BigDecimal accepts any int exponent, so a DECIMAL literal such as DECIMAL '1E2147483647' (~12 characters) parses to a BigDecimal whose plain-notation form would be one character per digit: a multi-gigabyte allocation (potentially an OOM error).

Three places call BigDecimal.toPlainString() on a value derived from user-supplied input and would attempt that allocation:

    SqlParserUtil.parseDecimalLiteral
    SqlNumericLiteral.toValue
    RexBuilder.makeLiteral

It is required to add a check in there to prevent an OOM error.