### PR TITLE
[CALCITE-7691] The behavior of SESSION table functions is unspecified…

### DIFF
--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/EnumUtils.java
@@ -1209,6 +1209,9 @@ public class EnumUtils {
       Map<@Nullable Object, NavigableMap<Pair<Long, Long>, List<@Nullable Object[]>>>
           sessionKeyMap = new HashMap<>();
       for (@Nullable Object[] element : elements) {
+        if (element[indexOfWatermarkedColumn] == null) {
+          continue;
+        }
         // A key column index of -1 means that there is no key; every element
         // then maps to the same (null) key, forming one session timeline.
         Object key = indexOfKeyColumn < 0 ? null : element[indexOfKeyColumn];

--- a/core/src/test/resources/sql/stream.iq
+++ b/core/src/test/resources/sql/stream.iq
@@ -374,3 +374,23 @@ SELECT * FROM TABLE(
 (3 rows)
 
 !ok
+
+# Test case for [CALCITE-7691] SESSION table function should drop rows
+# with a NULL timestamp rather than throwing.
+SELECT * FROM TABLE(
+  SESSION(
+    (SELECT * FROM (VALUES
+      (TIMESTAMP '2020-01-01 10:00:00', 'a'),
+      (CAST(NULL AS TIMESTAMP), 'a'),
+      (TIMESTAMP '2020-01-01 10:05:00', 'a')) AS T(TS, UID)),
+    DESCRIPTOR(TS), DESCRIPTOR(UID), INTERVAL '15' MINUTE))
+ORDER BY TS;
++---------------------+-----+---------------------+---------------------+
+| TS                  | UID | window_start        | window_end          |
++---------------------+-----+---------------------+---------------------+
+| 2020-01-01 10:00:00 | a   | 2020-01-01 10:00:00 | 2020-01-01 10:20:00 |
+| 2020-01-01 10:05:00 | a   | 2020-01-01 10:00:00 | 2020-01-01 10:20:00 |
++---------------------+-----+---------------------+---------------------+
+(2 rows)
+
+!ok


### PR DESCRIPTION
The behavior of SESSION table functions is unspecified for NULL timestamps

Jira Link
[CALCITE-7691](https://issues.apache.org/jira/browse/CALCITE-7691)

Changes Proposed

The behavior of the SESSION table function was undefined when the timestamp
column contained NULL values: SessionizationEnumerator.initialize() called
requireNonNull on the watermark column, so any row with a NULL timestamp
caused a NullPointerException at runtime instead of a well-defined result.

This is a one-line change that makes rows with a NULL timestamp be silently
dropped from the session computation, rather than throwing. This matches the
behavior of most SQL aggregate functions, which ignore NULL inputs, and
avoids changing the (currently NOT NULL) return type of the window_start
and window_end columns.

A test case has been added to stream.iq covering a SESSION query whose
input contains a mix of NULL and non-NULL timestamps.