### PR TITLE
[CALCITE-6648] IGNORE NULLS / RESPECT NULLS window function option can result in a type validation error in SqlToRelConverter

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlToRelConverterTest.java
@@ -3115,6 +3115,23 @@ class SqlToRelConverterTest extends SqlToRelTestBase {
     sql(sql).ok();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6648">[CALCITE-6648]
+   * IGNORE NULLS / RESPECT NULLS window function option can result in a type
+   * validation error in SqlToRelConverter</a>.
+   */
+  @Test void testOverNullTreatmentWithOffsetRowsFrame() {
+    final String sql = "select\n"
+        + "first_value(deptno) ignore nulls over "
+        + "(order by empno rows 1 preceding),\n"
+        + "last_value(deptno) respect nulls over "
+        + "(order by empno rows 1 preceding),\n"
+        + "nth_value(deptno, 2) ignore nulls over "
+        + "(order by empno rows 1 preceding)\n"
+        + "from emp";
+    sql(sql).ok();
+  }
+
   /**
    * Tests that a window with a FOLLOWING bound becomes BETWEEN CURRENT ROW
    * AND FOLLOWING.

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -4082,6 +4082,39 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   }
 
   /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6648">[CALCITE-6648]
+   * IGNORE NULLS / RESPECT NULLS window function option can result in a type
+   * validation error in SqlToRelConverter</a>.
+   *
+   * <p>When the input is a non-nullable type, the null treatment option is
+   * specified, and the window frame is ROWS with an offset-based bound (e.g.
+   * {@code n PRECEDING}), the window may be out of bounds, so the derived type
+   * must be nullable. Previously the null treatment wrapper caused the
+   * validation phase to derive a non-nullable type, which then diverged from
+   * the nullable type derived during conversion. */
+  @Test void testWindowNullTreatmentNullableWithOffsetRowsFrame() {
+    // EMPNO is non-nullable; with an offset-based ROWS frame the result may be
+    // null, so IGNORE NULLS / RESPECT NULLS must not force a non-nullable type.
+    winSql("select first_value(empno) ignore nulls over "
+        + "(order by empno rows 1 preceding)\n"
+        + "from emp")
+        .type("RecordType(INTEGER EXPR$0) NOT NULL");
+
+    winSql("select last_value(empno) respect nulls over "
+        + "(order by empno rows 1 preceding)\n"
+        + "from emp")
+        .type("RecordType(INTEGER EXPR$0) NOT NULL");
+
+    // A full-partition frame is always non-empty, so the result stays
+    // non-nullable even with null treatment.
+    winSql("select first_value(empno) ignore nulls over "
+        + "(order by empno rows between unbounded preceding "
+        + "and unbounded following)\n"
+        + "from emp")
+        .type("RecordType(INTEGER NOT NULL EXPR$0) NOT NULL");
+  }
+
+  /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-1954">[CALCITE-1954]
    * Column from outer join should be null, whether or not it is aliased</a>. */
   @Test void testLeftOuterJoinWithAlias() {

--- a/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/SqlToRelConverterTest.xml
@@ -7072,6 +7072,21 @@ LogicalProject(EXPR$0=[LEAD($7, 1) OVER (ORDER BY $0)], EXPR$1=[LEAD($7, 2) IGNO
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testOverNullTreatmentWithOffsetRowsFrame">
+    <Resource name="sql">
+      <![CDATA[select
+first_value(deptno) ignore nulls over (order by empno rows 1 preceding),
+last_value(deptno) respect nulls over (order by empno rows 1 preceding),
+nth_value(deptno, 2) ignore nulls over (order by empno rows 1 preceding)
+from emp]]>
+    </Resource>
+    <Resource name="plan">
+      <![CDATA[
+LogicalProject(EXPR$0=[FIRST_VALUE($7) IGNORE NULLS OVER (ORDER BY $0 ROWS 1 PRECEDING)], EXPR$1=[LAST_VALUE($7) OVER (ORDER BY $0 ROWS 1 PRECEDING)], EXPR$2=[NTH_VALUE($7, 2) IGNORE NULLS OVER (ORDER BY $0 ROWS 1 PRECEDING)])
+  LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testOverOrderFollowingWindow">
     <Resource name="sql">
       <![CDATA[select


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/CALCITE-6648

Based on the Jira discussion, complete test cases demonstrating the issue were not provided at the time; I have since added the relevant tests, and it appears the issue is now resolved.