### PR TITLE
[CALCITE-7731] Bound plain-notation expansion of DECIMAL literals to prevent parse-time OutOfMemoryError (follow-up, added more tests)

### DIFF
--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -117,6 +117,7 @@ import org.junit.jupiter.api.Test;
 import org.opentest4j.TestAbortedException;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -132,8 +133,10 @@ import static org.apache.calcite.test.Matchers.isLinux;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasToString;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -426,6 +429,27 @@ class RelToSqlConverterTest {
         + " AS \"t\" (\"a\", \"b\")";
     assertThat(toSqlPreservingLiteralTypes(root, dialect),
         isLinux(expectedPreserved));
+  }
+
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7731">[CALCITE-7731]
+   * Bound plain-notation expansion of DECIMAL literals to prevent parse-time
+   * OutOfMemoryError</a>. A DECIMAL literal whose plain-notation expansion would
+   * exceed the configured bound must not be converted to SQL text. */
+  @Test void testDecimalLiteralPlainNotationBoundInRelToSql() {
+    final RelBuilder b = relBuilder();
+    final RexBuilder rexBuilder = b.getRexBuilder();
+    // A literal with 20,000 digits comfortably exceeds the default 10,000
+    // digit bound, without requiring a multi-gigabyte allocation to build.
+    final BigDecimal outOfBound = new BigDecimal(BigInteger.TEN.pow(20_000));
+    final RelNode root = b
+        .scan("EMP")
+        .project(rexBuilder.makeExactLiteral(outOfBound))
+        .build();
+    final SqlDialect dialect = DatabaseProduct.CALCITE.getDialect();
+    final IllegalStateException e =
+        assertThrows(IllegalStateException.class, () -> toSql(root, dialect));
+    assertThat(e.getMessage(),
+        containsString("exceeds the configured plain-notation bound"));
   }
 
   /** Parses a SQL query and converts it to a relational expression. */

--- a/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexBuilderTest.java
@@ -772,6 +772,26 @@ class RexBuilderTest {
     assertThat(rexLiteralHalfUp.getValue(), hasToString("12300"));
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7731">[CALCITE-7731]
+   * Bound plain-notation expansion of DECIMAL literals to prevent parse-time
+   * OutOfMemoryError</a>. Casting to a DECIMAL type whose (dialect-permitted)
+   * negative scale would make the plain-notation expansion exceed the
+   * configured bound must fail rather than attempt the expansion. */
+  @Test void testDecimalWithNegativeScaleExceedingPlainNotationBound() {
+    final RelDataTypeFactory typeFactory =
+        new SqlTypeFactoryImpl(
+            CustomTypeSystems.withMinScale(RelDataTypeSystem.DEFAULT,
+                typeName -> -20_000));
+    final RelDataType type = typeFactory.createSqlType(SqlTypeName.DECIMAL, 3, -20_000);
+    final RexBuilder builder = new RexBuilder(typeFactory);
+    final BigDecimal value = new BigDecimal("123");
+    final IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+      builder.makeLiteral(value, type);
+    });
+    assertThat(e.getMessage(),
+        containsString("plain-notation expansion exceeds the configured bound"));
+  }
+
   /** Tests {@link DateString} year range. */
   @Test void testDateStringYearError() {
     try {

--- a/core/src/test/java/org/apache/calcite/sql/SqlNodeTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/SqlNodeTest.java
@@ -23,6 +23,8 @@ import org.apache.calcite.util.Litmus;
 import org.apache.calcite.util.TestUtil;
 import org.apache.calcite.util.Util;
 
+import com.google.common.base.Strings;
+
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
@@ -35,7 +37,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test of {@link SqlNode} and other SQL AST classes.
@@ -72,6 +76,24 @@ class SqlNodeTest {
   @Test void testRowEqualsDeep() {
     assertThat("CAST(a AS ROW(field INTEGER))",
         isEqualsDeep("CAST(a AS ROW(field INTEGER))"));
+  }
+
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7731">[CALCITE-7731]
+   * Bound plain-notation expansion of DECIMAL literals to prevent parse-time
+   * OutOfMemoryError</a>. A {@link SqlNumericLiteral} whose value's plain-notation
+   * expansion would exceed the configured bound must fail when unparsed, even if
+   * the literal was not created via the SQL parser. */
+  @Test void testNumericLiteralToValueExceedingPlainNotationBound() {
+    // A literal with a 20,001-digit fractional expansion comfortably exceeds
+    // the default 10,000 digit bound, without requiring a multi-gigabyte
+    // allocation to build.
+    final String digits = "0." + Strings.repeat("0", 20_000) + "1";
+    final SqlNumericLiteral literal =
+        SqlLiteral.createExactNumeric(digits, SqlParserPos.ZERO);
+    final IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, literal::toValue);
+    assertThat(e.getMessage(),
+        containsString("exceeds the configured plain-notation bound"));
   }
 
   private static Matcher<String> isEqualsDeep(String sqlExpected) {


### PR DESCRIPTION
Follow-up to #5204, requested by @rubenada in https://github.com/apache/calcite/pull/5204#issuecomment-5385243886.

This adds direct regression tests for the three CALCITE-7731 plain-notation guards outside the parser path:

- RexBuilder.makeLiteral with a dialect-permitted negative DECIMAL scale
- Rel-to-SQL conversion of an oversized exact DECIMAL literal
- SqlNumericLiteral.toValue for a directly constructed literal

Each test uses a bounded input of roughly 20,000 digits and verifies the specific guard exception. No production code changes are included.

Validation on current main with Java 21 and the pinned Gradle 8.14.4 wrapper:

- focused new tests: 3 passed, 0 failed
- RelToSqlConverterTest: 623 passed, 0 failed
- RexBuilderTest: 72 passed, 0 failed
- SqlNodeTest: 4 passed, 0 failed
- core Checkstyle and AutoStyle: passed
- :core:build: 16,658 completed, 0 failed, 155 skipped
- repository-wide build: BUILD SUCCESSFUL, 413 tasks

The initial missing cases were identified by JAIPilot Cloud, then rebased, reviewed, and independently validated against the latest upstream main.