### PR TITLE
Reduce AGENTS.md to a bare minimum

### DIFF
--- a/.ratignore
+++ b/.ratignore
@@ -15,6 +15,7 @@
 .idea/vcs.xml
 SECURITY.md
 AGENTS.md
+CLAUDE.md
 example/csv/src/test/resources/smoke_test.sql
 
 # TODO: remove when pom.xml files are removed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,43 +1,9 @@
 # Agent guidance
 
-This file is read by automated agents (security scanners, code analyzers,
-AI assistants) operating on this repository. It points them at the
-human-authored references they should consult before producing output.
+Apache Calcite is a dynamic data management framework. It provides a SQL
+parser and validator, a customizable cost-based optimizer, and relational
+algebra operators, without a storage engine of its own.
 
 ## Security
 
-Security model: [SECURITY.md](./SECURITY.md), which links to the project's
-threat model at
-[site/_docs/security_threat_model.md](./site/_docs/security_threat_model.md).
-
-Calcite is an embedded SQL framework, not a server. It opens no socket and
-has no authentication or authorization of its own; the host application
-owns transport, identity, and schema scoping. Read the threat model before
-reporting anything — it is explicit about what it does and does not treat
-as a vulnerability.
-
-Two rules carry most of the triage weight:
-
-- **Surprising vs unsurprising class loading.** A class named through a
-  Calcite SPI position — `schemaFactory`, `parserFactory`, `typeSystem`,
-  `metaTableFactory`, `metaColumnFactory`, `tableFactory`, function
-  classes, `dataSource`, `jdbcDriver`, `model` — is loaded only through
-  that SPI, gated by `Class.forName(name, false, loader)` plus an
-  `isAssignableFrom` check. A class that does not implement the SPI for
-  its position is never instantiated by name. SQL may name SPI classes,
-  but only SPI implementations run, and only through their SPI.
-- **Pushed-down SQL.** The SQL Calcite generates and sends to a backend
-  the operator configured is *not* a vulnerability — the query author can
-  already reach that endpoint through the visible schemas. A pushdown bug
-  that reads *beyond* the configured schemas is P4 and *is* one.
-
-Explicitly not vulnerabilities (see the model's "Not a vulnerability"
-section): the os-adapter running OS commands, the file/CSV/JSON adapters
-reading paths they were configured with, anything requiring a changed
-system property or classpath, a third-party driver's behaviour past the
-connection boundary, and cross-tenant reads that follow from the embedder
-exposing several principals' schemas on one connection.
-
-The model also lists what belongs to the host rather than the library —
-transport and identity, schema scoping, adapter selection, the classpath,
-and whatever a `model` points at — under "Downstream responsibilities".
+See [SECURITY.md](./SECURITY.md) before reporting a vulnerability.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Why
AGENTS.md restated the full security threat model — the SPI class-loading gate, the pushed-down-SQL rule, the "not a vulnerability" list, and the "downstream responsibilities" list — that already lives in [SECURITY.md](https://github.com/apache/calcite/blob/main/SECURITY.md) and the linked threat model. Keeping two copies means they can drift out of sync.

## What
Cuts AGENTS.md down to a one-paragraph description of what Apache Calcite is, plus a link to SECURITY.md for anything security-related, instead of duplicating its content.

## How to verify
Docs only; no production code touched. Read the new [AGENTS.md](https://github.com/apache/calcite/blob/claude/agents-md-minimal-deb238/AGENTS.md) and confirm it still points agents at SECURITY.md.