### PR TITLE
[CALCITE-7558] Lattice.Measure.compareTo() collapses distinct aggregates that share the same name

### DIFF
--- a/core/src/main/java/org/apache/calcite/materialize/Lattice.java
+++ b/core/src/main/java/org/apache/calcite/materialize/Lattice.java
@@ -43,6 +43,7 @@ import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlJoin;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -72,6 +73,7 @@ import org.checkerframework.checker.nullness.qual.RequiresNonNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
@@ -577,6 +579,12 @@ public class Lattice {
    * COUNT(DISTINCT customer.id).
    */
   public static class Measure implements Comparable<Measure> {
+    /** Distinguishes aggregate functions that have the same name, using the
+     * other properties that {@link SqlOperator#equals(Object)} compares. */
+    private static final Comparator<SqlOperator> AGG_TIE_BREAKER =
+        Comparator.comparing((SqlOperator op) -> op.getKind().name())
+            .thenComparing((SqlOperator op) -> op.getClass().getName());
+
     public final SqlAggFunction agg;
     public final boolean distinct;
     public final @Nullable String name;
@@ -615,6 +623,9 @@ public class Lattice {
         c = agg.getName().compareTo(measure.agg.getName());
         if (c == 0) {
           c = Boolean.compare(distinct, measure.distinct);
+          if (c == 0) {
+            c = AGG_TIE_BREAKER.compare(agg, measure.agg);
+          }
         }
       }
       return c;

--- a/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
+++ b/core/src/test/java/org/apache/calcite/materialize/LatticeSuggesterTest.java
@@ -20,13 +20,19 @@ import org.apache.calcite.materialize.Lattice.Measure;
 import org.apache.calcite.prepare.PlannerImpl;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperatorTable;
+import org.apache.calcite.sql.fun.SqlBasicAggFunction;
 import org.apache.calcite.sql.fun.SqlLibrary;
 import org.apache.calcite.sql.fun.SqlLibraryOperatorTableFactory;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.statistic.MapSqlStatisticProvider;
 import org.apache.calcite.statistic.QuerySqlStatisticProvider;
@@ -56,6 +62,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.TreeSet;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 
@@ -69,6 +76,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasToString;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Unit tests for {@link LatticeSuggester}.
@@ -846,6 +854,36 @@ class LatticeSuggesterTest {
         + "GROUP BY \"num_children_at_home\" + 10, CAST(\"num_children_at_home\" AS DOUBLE) + 11";
     assertThat(lattice.sql(groupSet, true, measures),
         is(sql));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7558">[CALCITE-7558]
+   * Lattice.Measure.compareTo() collapses distinct aggregates that share the
+   * same name</a>. */
+  @Test void testMeasureNaturalOrderingKeepsDistinctAggregatorsWithSameName() {
+    final SqlAggFunction builtInSum = SqlStdOperatorTable.SUM;
+    final SqlAggFunction sameKindSum =
+        SqlBasicAggFunction.create("SUM", SqlKind.SUM,
+            ReturnTypes.ARG0_NULLABLE, OperandTypes.NUMERIC);
+    final SqlAggFunction otherKindSum =
+        SqlBasicAggFunction.create("SUM", SqlKind.OTHER_FUNCTION,
+            ReturnTypes.ARG0_NULLABLE, OperandTypes.NUMERIC);
+
+    final Measure builtInMeasure =
+        new Measure(builtInSum, false, "SUM", ImmutableList.of());
+    final Measure sameKindMeasure =
+        new Measure(sameKindSum, false, "SUM", ImmutableList.of());
+    final Measure otherKindMeasure =
+        new Measure(otherKindSum, false, "SUM", ImmutableList.of());
+    assertNotEquals(builtInMeasure, sameKindMeasure);
+    assertNotEquals(builtInMeasure, otherKindMeasure);
+    assertNotEquals(sameKindMeasure, otherKindMeasure);
+
+    final TreeSet<Measure> measures = new TreeSet<>();
+    measures.add(builtInMeasure);
+    measures.add(sameKindMeasure);
+    measures.add(otherKindMeasure);
+    assertThat(measures, hasSize(3));
   }
 
   private void checkFoodmartSimpleJoin(CalciteAssert.SchemaSpec schemaSpec)


### PR DESCRIPTION
## Jira Link

[CALCITE-7558](https://issues.apache.org/jira/browse/CALCITE-7558)

## Changes Proposed

A lattice can contain a built-in aggregate and a user-defined aggregate with the same name. `Lattice.Measure.compareTo()` treated those measures as equal even when `SqlOperator.equals()` did not, so the builder's `TreeSet` silently discarded one of them. Current main retains one of three unequal measures in the regression; this branch retains all three.

The natural order still compares arguments, aggregate name, and the distinct flag in the same order as before. Aggregate kind and implementation class now break only ties that previously collapsed unequal measures.

### Testing

```console
$ SOURCE=core/src/main/java/org/apache/calcite/materialize/Lattice.java
$ git checkout c46c70cb26 -- "$SOURCE"
$ JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :core:test \
    --tests 'org.apache.calcite.materialize.LatticeSuggesterTest.testMeasureNaturalOrderingKeepsDistinctAggregatorsWithSameName' \
    --no-daemon --console=plain
Expected: a collection with size <3>
     but: collection size was <1>

$ git checkout a8981422fa -- "$SOURCE"
$ JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :core:test \
    --tests 'org.apache.calcite.materialize.LatticeSuggesterTest.testMeasureNaturalOrderingKeepsDistinctAggregatorsWithSameName' \
    --no-daemon --console=plain
0.1sec, 1 completed, 0 failed, 0 skipped
BUILD SUCCESSFUL
```
