### PR TITLE
[CALCITE-6089] EnumerableSortedAggregate fails with ClassCastException: class X cannot be cast to class org.apache.calcite.runtime.FlatLists$ComparableList

### DIFF
--- a/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableSortedAggregateTest.java
+++ b/core/src/test/java/org/apache/calcite/test/enumerable/EnumerableSortedAggregateTest.java
@@ -74,6 +74,34 @@ public class EnumerableSortedAggregateTest {
         .throws_("There are not enough rules to produce a node with desired properties");
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-6089">[CALCITE-6089]
+   * EnumerableSortedAggregate fails with ClassCastException: class X cannot be
+   * cast to class org.apache.calcite.runtime.FlatLists$ComparableList</a>. */
+  @Test void sortedAggCountUnionRejectsEmptyGroupSet() {
+    tester(false, new HrSchema())
+        .query("select count(*) as c from ( "
+            + "select * from emps where deptno=10 "
+            + "union all "
+            + "select * from emps where deptno=20)")
+        .withHook(Hook.PLANNER, (Consumer<RelOptPlanner>) planner -> {
+          planner.removeRule(EnumerableRules.ENUMERABLE_AGGREGATE_RULE);
+          planner.addRule(EnumerableRules.ENUMERABLE_SORTED_AGGREGATE_RULE);
+        })
+        .throws_("There are not enough rules to produce a node with desired properties");
+  }
+
+  /** As {@link #sortedAggCountUnionRejectsEmptyGroupSet()}, but with the
+   * default rules. */
+  @Test void sortedAggCountUnion() {
+    tester(false, new HrSchema())
+        .query("select count(*) as c from ( "
+            + "select * from emps where deptno=10 "
+            + "union all "
+            + "select * from emps where deptno=20)")
+        .returnsOrdered("c=4");
+  }
+
   @Test void sortedAggTwoGroupKeys() {
     tester(false, new HrSchema())
         .query(


### PR DESCRIPTION
## Jira Link

[CALCITE-6089](https://issues.apache.org/jira/browse/CALCITE-6089)

## Changes Proposed

Counting rows over a `UNION ALL` failed at runtime when the sorted aggregate was
used:

```
java.lang.ClassCastException: class java.lang.Integer cannot be cast to class
org.apache.calcite.runtime.FlatLists$ComparableList
```

The query now returns `c=4`.

The aggregate has no group key. The rule used to convert it anyway, and
comparing the zero-length keys threw. CALCITE-6087 made the rule decline an
empty group set, so no sorted aggregate is produced, the planner uses the
regular aggregate, and the query succeeds. That fix therefore closed this issue
too, so this PR adds only the regression tests requested when #5202 merged.

Two tests, following the pattern that patch established. One forces the sorted
rule and asserts the planner now rejects the plan; the other runs the query with
the usual rule set and asserts the result.

### Testing

Running the suite on this branch, which is current main plus the two new tests:

```console
$ ./gradlew :core:test --tests '*EnumerableSortedAggregateTest'
15 completed, 0 failed, 0 skipped
BUILD SUCCESSFUL
```

Reverting only the one-line rule change from CALCITE-6087, and keeping the new
tests, reproduces the original failure:

```console
$ git checkout bd65b15fc6^ -- core/src/main/java/org/apache/calcite/adapter/enumerable/EnumerableSortedAggregateRule.java
$ ./gradlew :core:test --tests '*EnumerableSortedAggregateTest.sortedAggCountUnion*'
FAILURE sortedAggCountUnionRejectsEmptyGroupSet()
  but: was "java.sql.SQLException: Error while executing SQL ...:
  class java.lang.Integer cannot be cast to class
  org.apache.calcite.runtime.FlatLists$ComparableList"
2 completed, 1 failed
```

## Are there any user-facing changes?

No. Tests only.
