### PR TITLE
[CALCITE-7744] ORDER BY agg(col) on a query where an alias shadows col produces an invalid plan containing an aggregate call in a Project

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -5484,6 +5484,7 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
     final RelDataType type = deriveType(scope, orderExpr2);
     setValidatedNodeType(orderExpr2, type);
     if (!type.isMeasure()) {
+      orderExpr2.validate(this, getSelectScope(select));
       return orderExpr2;
     }
 

--- a/core/src/test/java/org/apache/calcite/test/JdbcTest.java
+++ b/core/src/test/java/org/apache/calcite/test/JdbcTest.java
@@ -3391,6 +3391,14 @@ public class JdbcTest {
             + "store_id=0; grocery_sqft=null\n");
   }
 
+  @Test void testOrderByAggregateAliasShadowing() {
+    CalciteAssert.that()
+        .with(CalciteAssert.Config.SCOTT)
+        .query("SELECT max(sal) AS sal, deptno, job "
+            + "FROM emp GROUP BY deptno, job ORDER BY max(sal)")
+        .throws_("Aggregate expressions cannot be nested");
+  }
+
   /** Tests ORDER BY ... DESC. Nulls come first (they come last for ASC). */
   @Test void testOrderByDesc() {
     CalciteAssert.that()

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -5067,6 +5067,8 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     // various kinds of measure expressions
     sql("select deptno, empno + 1 as measure e1 from emp").ok();
     sql("select *, empno + 1 as measure e1 from emp").ok();
+    sql("select deptno + 1 as d1, d1 + 2 as measure d3\n"
+        + "from emp order by d3").ok();
 
     // an aggregate function in a measure does not make it an aggregate query
     sql("select *, sum(empno) as measure e1 from emp").ok();


### PR DESCRIPTION
## Jira Link

[CALCITE-7744](https://issues.apache.org/jira/browse/CALCITE-7744)

## Changes Proposed

`SELECT max(sal) AS sal, deptno, job FROM emp GROUP BY deptno, job ORDER BY max(sal)` passes validation but fails during execution with `Unable to implement EnumerableCalc`.

The ORDER BY alias expansion turns the expression into `max(max(sal))` after the original expression has already been validated. The inner aggregate then leaks into a `Project`. Validate expanded non-measure ORDER BY expressions before SQL-to-rel conversion. The query now returns Calcite's existing `Aggregate expressions cannot be nested` validation error instead of building an illegal plan. Measure aliases retain their existing scope and conversion path.

### Verification

```shell
JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :core:test \
  --tests org.apache.calcite.test.SqlValidatorTest \
  --tests org.apache.calcite.test.JdbcTest --no-daemon
```

The JDBC regression uses `CalciteAssert.Config.SCOTT` and the query above. The same test ran against production source from `upstream/main` and from this branch.

<details>
<summary>Raw logs</summary>

```text
Before:
java.sql.SQLException: Unable to implement EnumerableCalc(...)
  EnumerableAggregate(group=[{0, 1}], SAL=[MAX($2)], agg#1=[MAX($3)])
    EnumerableCalc(... expr#8=[MAX($t5)] ...)
Suppressed: java.lang.RuntimeException: cannot translate call MAX($t5)
1 test completed, 1 failed

After:
SqlValidatorTest: 593 completed, 0 failed, 7 skipped
JdbcTest: 409 completed, 0 failed, 17 skipped
Gradle Test Run :core:test: 1002 completed, 0 failed, 24 skipped
BUILD SUCCESSFUL
```

</details>
