### PR TITLE
[CALCITE-7747] RexSimplify.simplifySearch does not simplify SEARCH(li…

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -2547,9 +2547,13 @@ public class RexSimplify {
               call.clone(call.type, ImmutableList.of(searchOperand, literal2)),
               unknownAs);
         }
+      } else if (searchOperand instanceof RexLiteral) {
+        // Subject is a constant; expand and re-simplify regardless of point count,
+        // since a constant subject can always be fully evaluated.
+        return simplify(RexUtil.expandSearch(rexBuilder, null, call), unknownAs);
       } else if (sarg.isPoints() && sarg.pointCount <= 1) {
-        // Expand "SEARCH(x, Sarg([point])" to "x = point"
-        // and "SEARCH(x, Sarg([])" to "false"
+        // Expand "SEARCH(x, Sarg([point]))" to "x = point"
+        // and "SEARCH(x, Sarg([]))" to "false".
         return RexUtil.expandSearch(rexBuilder, null, call);
       }
     }

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -2261,6 +2261,27 @@ class RexProgramTest extends RexProgramTestBase {
   }
 
   /** Unit test for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7747">[CALCITE-7747]
+   * RexSimplify.simplifySearch does not simplify SEARCH(literal, Sarg) when
+   * pointCount >= 2</a>. */
+  @Test void testSimplifySearchWithLiteralOperandAndMultiPointSargNotFolded() {
+    final RangeSet<BigDecimal> rangeSet =
+        ImmutableRangeSet.<BigDecimal>builder()
+            .add(Range.singleton(BigDecimal.valueOf(1)))
+            .add(Range.singleton(BigDecimal.valueOf(2)))
+            .build();
+    final Sarg<BigDecimal> sarg = Sarg.of(RexUnknownAs.UNKNOWN, rangeSet);
+    final RexLiteral searchLiteral =
+        rexBuilder.makeSearchArgumentLiteral(sarg, tInt());
+    final RexNode literalOperand = literal(5);
+    final RexNode searchCall =
+        rexBuilder.makeCall(SqlStdOperatorTable.SEARCH, literalOperand, searchLiteral);
+    // Expected (and true pre-Sarg, when this was OR(=(5,1), =(5,2))): folds to "false".
+    // Actual: simplifySearch returns the SEARCH call unchanged.
+    checkSimplify(searchCall, "false");
+  }
+
+  /** Unit test for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-5759">[CALCITE-5759]
    * 'SEARCH(1, Sarg[IS NOT NULL])' should be simplified to 'TRUE'</a>. */
   @Test void testSimplifySearchWithSpecialSargIsNotNull() {


### PR DESCRIPTION
…teral, Sarg) when pointCount >= 2

RexSimplify.simplifySearch only evaluated a SEARCH(subject, Sarg) call against its Sarg when sarg.isPoints() && sarg.pointCount <= 1, with no check for whether the subject itself is a constant. A single-point Sarg with any subject folded correctly, and a multi-point Sarg with a column-reference subject simplified correctly elsewhere, but a literal subject compared against a multi-point Sarg (for example, SEARCH(5, Sarg[1, 2])) fell through every branch unevaluated instead of folding to a boolean constant.

This can occur whenever a rule substitutes a literal for a column reference in a SEARCH condition, such as when
FilterSetOpTransposeRule pushes a filter through a branch of a Union that projects a constant.

## Jira Link
[CALCITE-7747](https://issues.apache.org/jira/browse/CALCITE-7747)

## Changes Proposed
<!--
Fix simplifySearch so that when the search subject is itself a RexLiteral, the call is expanded via the existing RexUtil.expandSearch and the result is simplified recursively, regardless of point count. This matches the treatment already given to a single-point Sarg, but adds the recursive simplify() call needed to fold the expanded comparison tree down to a constant.
-->
