### PR TITLE
[CALCITE-7749] CONCAT (and other STRING_SAME_SAME-typed operators) gives misleading error message for mixed CHARACTER/BINARY arguments

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/OperandTypes.java
@@ -57,6 +57,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -1133,15 +1134,19 @@ public abstract class OperandTypes {
    * Operand type-checking strategy where two operands must both be in the
    * same string type family.
    */
+  private static final ImmutableList<SqlTypeFamily> STRING_SUB_FAMILIES =
+      ImmutableList.of(SqlTypeFamily.CHARACTER, SqlTypeFamily.BINARY);
   public static final SqlSingleOperandTypeChecker STRING_SAME_SAME =
-      STRING_STRING.and(SAME_SAME);
+      withSignatureGenerator(STRING_STRING.and(SAME_SAME),
+          sameSubFamilySignatureGenerator(2, STRING_SUB_FAMILIES));
 
   /**
    * Operand type-checking strategy where three operands must all be in the
    * same string type family.
    */
   public static final SqlSingleOperandTypeChecker STRING_SAME_SAME_SAME =
-      STRING_STRING_STRING.and(SAME_SAME_SAME);
+      withSignatureGenerator(STRING_STRING_STRING.and(SAME_SAME_SAME),
+          sameSubFamilySignatureGenerator(3, STRING_SUB_FAMILIES));
 
   public static final SqlSingleOperandTypeChecker STRING_STRING_INTEGER =
       family(SqlTypeFamily.STRING, SqlTypeFamily.STRING, SqlTypeFamily.INTEGER);
@@ -1192,8 +1197,8 @@ public abstract class OperandTypes {
    * same string type family and last type is INTEGER.
    */
   public static final SqlSingleOperandTypeChecker STRING_SAME_SAME_INTEGER =
-      STRING_STRING_INTEGER.and(SAME_SAME_INTEGER);
-
+      withSignatureGenerator(STRING_STRING_INTEGER.and(SAME_SAME_INTEGER),
+          sameSubFamilySignatureGenerator(2, STRING_SUB_FAMILIES, SqlTypeFamily.INTEGER));
   public static final SqlSingleOperandTypeChecker STRING_SAME_SAME_OR_ARRAY_SAME_SAME =
       or(STRING_SAME_SAME,
           and(OperandTypes.SAME_SAME, family(SqlTypeFamily.ARRAY, SqlTypeFamily.ARRAY)));
@@ -1498,6 +1503,75 @@ public abstract class OperandTypes {
       }
       return !validationError;
     }
+  }
+  /**
+   * Wraps a {@link SqlSingleOperandTypeChecker}, overriding only its
+   * {@link SqlOperandTypeChecker#getAllowedSignatures}, while delegating
+   * everything else unchanged. Used instead of
+   * {@link CompositeOperandTypeChecker#withGenerator}, which always returns
+   * a plain {@link CompositeOperandTypeChecker} and would lose single-operand
+   * checking.
+   */
+  private static SqlSingleOperandTypeChecker withSignatureGenerator(
+      SqlSingleOperandTypeChecker checker,
+      BiFunction<SqlOperator, String, String> signatureGenerator) {
+    return new SqlSingleOperandTypeChecker() {
+      @Override public boolean checkSingleOperandType(SqlCallBinding callBinding,
+          SqlNode operand, int iFormalOperand, boolean throwOnFailure) {
+        // STRING_SAME_SAME-style checkers evaluate family membership AND
+        // cross-operand comparability together; there's no meaningful way to
+        // validate a single operand in isolation, so fall back to the full
+        // multi-operand check.
+        return checker.checkOperandTypes(callBinding, throwOnFailure);
+      }
+
+      @Override public boolean checkOperandTypes(SqlCallBinding callBinding,
+          boolean throwOnFailure) {
+        // Explicitly override rather than relying on the interface default
+        // (which would route through checkSingleOperandType(operand(0), 0)
+        // and only ever check the first operand).
+        return checker.checkOperandTypes(callBinding, throwOnFailure);
+      }
+
+      @Override public SqlOperandCountRange getOperandCountRange() {
+        return checker.getOperandCountRange();
+      }
+
+      @Override public boolean isOptional(int i) {
+        return checker.isOptional(i);
+      }
+
+      @Override public Consistency getConsistency() {
+        return checker.getConsistency();
+      }
+
+      @Override public String getAllowedSignatures(SqlOperator op, String opName) {
+        return signatureGenerator.apply(op, opName);
+      }
+    };
+  }
+
+  /**
+   * Builds an error-message generator that lists one candidate signature per
+   * given sub-family, each repeated across the "same" operand positions,
+   * followed by any trailing fixed families (see CALCITE-7749).
+   */
+  private static BiFunction<SqlOperator, String, String> sameSubFamilySignatureGenerator(
+      int sameOperandCount, List<SqlTypeFamily> subFamilies,
+      SqlTypeFamily... trailingFamilies) {
+    return (op, opName) ->
+        subFamilies.stream()
+            .map(subFamily -> {
+              List<String> form = new ArrayList<>();
+              for (int i = 0; i < sameOperandCount; i++) {
+                form.add(subFamily.name());
+              }
+              for (SqlTypeFamily family : trailingFamilies) {
+                form.add(family.name());
+              }
+              return SqlUtil.getAliasedSignature(op, opName, form);
+            })
+            .collect(Collectors.joining(SqlOperator.NL));
   }
 
   /** Checker that returns whether a value is a collection (multiset or array)

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -872,8 +872,11 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
   @Test void testConcatFails() {
     wholeExpr("'a'||x'ff'")
         .fails("(?s).*Cannot apply '\\|\\|' to arguments of type "
-            + "'<CHAR.1.> \\|\\| <BINARY.1.>'.*Supported form.s.: "
-            + "'<STRING> \\|\\| <STRING>.*'");
+            + "'<CHAR\\(1\\)> \\|\\| <BINARY\\(1\\)>'.*"
+            + "Supported form\\(s\\): "
+            + "'<CHARACTER> \\|\\| <CHARACTER>'\\s*"
+            + "'<BINARY> \\|\\| <BINARY>'\\s*"
+            + "'<EQUIVALENT_TYPE> \\|\\| <EQUIVALENT_TYPE>'.*");
   }
 
   /** Tests the CONCAT function, which unlike the concat operator ('||') is not

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -2757,7 +2757,8 @@ public class SqlOperatorTest {
     f.checkFails("^concat('a', x'0a')^",
         "Cannot apply 'CONCAT' to arguments of type "
             + "'CONCAT\\(<CHAR\\(1\\)>, <BINARY\\(1\\)>\\)'\\. Supported "
-            + "form\\(s\\): 'CONCAT\\(<STRING>, <STRING>\\)'",
+            + "form\\(s\\): 'CONCAT\\(<CHARACTER>, <CHARACTER>\\)'\n"
+            + "'CONCAT\\(<BINARY>, <BINARY>\\)'",
         false);
   }
 
@@ -11873,7 +11874,8 @@ public class SqlOperatorTest {
       f.checkFails("^" + fn + "('aabbcc', x'aa')^",
           "Cannot apply '" + fn + "' to arguments of type "
               + "'" + fn + "\\(<CHAR\\(6\\)>, <BINARY\\(1\\)>\\)'\\. Supported "
-              + "form\\(s\\): '" + fn + "\\(<STRING>, <STRING>\\)'",
+              + "form\\(s\\): '" + fn + "\\(<CHARACTER>, <CHARACTER>\\)'\\n"
+              + "'" + fn + "\\(<BINARY>, <BINARY>\\)'",
           false);
       f.checkNull(fn + "(null, null)");
       f.checkNull(fn + "('12345', null)");
@@ -11913,7 +11915,8 @@ public class SqlOperatorTest {
       f.checkFails("^" + fn + "('aabbcc', x'aa')^",
           "Cannot apply '" + fn + "' to arguments of type "
               + "'" + fn + "\\(<CHAR\\(6\\)>, <BINARY\\(1\\)>\\)'\\. Supported "
-              + "form\\(s\\): '" + fn + "\\(<STRING>, <STRING>\\)'",
+              + "form\\(s\\): '" + fn + "\\(<CHARACTER>, <CHARACTER>\\)'\\s*"
+              + "'" + fn + "\\(<BINARY>, <BINARY>\\)'",
           false);
       f.checkNull(fn + "(null, null)");
       f.checkNull(fn + "('12345', null)");


### PR DESCRIPTION
CONCAT (and other STRING_SAME_SAME-typed operators) gives misleading error message for mixed CHARACTER/BINARY arguments

Jira Link
[CALCITE-7749](https://issues.apache.org/jira/browse/CALCITE-7749)

Changes Proposed

SqlTypeFamily.STRING is an aggregate family covering both CHARACTER and BINARY. Operators such as CONCAT (SqlLibraryOperators.CONCAT2) use OperandTypes.STRING_SAME_SAME, defined as STRING_STRING.and(SAME_SAME). Each operand independently passes STRING_STRING (since both CHAR and BINARY belong to the STRING family), so the constraint that actually rejects mixed CHARACTER/BINARY calls comes from the second, AND-composed rule SAME_SAME.

CompositeOperandTypeChecker#getAllowedSignatures, however, only includes the first sub-rule's signature for AND compositions and drops any subsequent rule's signature. As a result, the error message for e.g. CONCAT('a', x'0a') was:

Cannot apply 'CONCAT' to arguments of type 'CONCAT(<CHAR(1)>, <BINARY(1)>)'.
Supported form(s): 'CONCAT(<STRING>, <STRING>)'

which is misleading, since CONCAT does support BINARY arguments (e.g. CONCAT(x'0a', x'0b')); the real constraint is that both operands must belong to the same concrete sub-family.

This change adds a SqlSingleOperandTypeChecker wrapper in OperandTypes that overrides only getAllowedSignatures, delegating all type-checking behavior to the original checker unchanged, and attaches it to STRING_SAME_SAME, STRING_SAME_SAME_SAME, and STRING_SAME_SAME_INTEGER. The generated message now enumerates both concretely valid forms:

Supported form(s): 'CONCAT(<CHARACTER>, <CHARACTER>)'
'CONCAT(<BINARY>, <BINARY>)'

CompositeOperandTypeChecker#withGenerator was not used directly, because it always returns a plain CompositeOperandTypeChecker, which is not a SqlSingleOperandTypeChecker — casting the result throws ClassCastException at runtime for these fields.

STRING_SAME_SAME_OR_ARRAY_SAME_SAME requires no separate change, since it composes STRING_SAME_SAME via OR, and OR-composed signatures already aggregate all sub-rule signatures — it picks up the fix automatically.

Operators sharing STRING_SAME_SAME (CONCAT2, ENDS_WITH/ENDSWITH, STARTS_WITH/STARTSWITH) are all affected by this message change; CONCAT_FUNCTION (the MySQL/BigQuery variadic CONCAT, which uses OperandTypes.repeat(..., STRING) without SAME_SAME) is unrelated and unaffected.

Testing

Updated SqlOperatorTest#checkConcat2Func to assert the new two-form error message for CONCAT('a', x'0a').
Added/updated coverage confirming CONCAT('a', 'b') and CONCAT(x'0a', x'0b') still validate successfully (no regression to the underlying type-checking logic).