### PR TITLE
[CALCITE-7758] RexSimplify does not absorb redundant IS NOT NULL on non-input-ref sub-expressions in AND simplification

### DIFF
--- a/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSimplify.java
@@ -2139,6 +2139,25 @@ public class RexSimplify {
           strongOperands.add(rexFieldAccess);
         }
       }
+      // Also probe sub-expressions coming from IS_NOT_NULL(...) predicates that
+      // are not bare input refs or field accesses (e.g. CAST calls); without
+      // this, IS_NOT_NULL(CAST(x)) AND (CAST(x) + 1) < 10 would not be absorbed
+      for (RexNode operand : notNullOperands) {
+        if (operand instanceof RexInputRef
+            || operand instanceof RexFieldAccess
+            || strongOperands.contains(operand)
+            || !RexUtil.isDeterministic(operand)) {
+          continue;
+        }
+        final Strong strong = new Strong() {
+          @Override public boolean isNull(RexNode node) {
+            return node.equals(operand) || super.isNull(node);
+          }
+        };
+        if (strong.isNotTrue(term)) {
+          strongOperands.add(operand);
+        }
+      }
     }
     // If one column should be null and is in a comparison predicate,
     // it is not satisfiable.

--- a/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
+++ b/core/src/test/java/org/apache/calcite/rex/RexProgramTest.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.SqlBasicFunction;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
@@ -3023,6 +3024,41 @@ class RexProgramTest extends RexProgramTestBase {
     // do not simplify if one of the operands may throw an exception
     checkSimplifyUnchanged(div(nullInt, cast(vVarchar(), tInt(false))));
     checkSimplifyUnchanged(div(cast(vVarchar(), tInt(false)), nullInt));
+  }
+
+  /**
+   * Test cases for <a href="https://issues.apache.org/jira/browse/CALCITE-7758">[CALCITE-7758]
+   * RexSimplify does not absorb redundant IS NOT NULL on non-input-ref sub-expressions
+   * in AND simplification</a>.
+   */
+  @Test void testSimplifyIsNotNullAndStrongExpression() {
+    // "unsafe" cast: (CAST(a) + 1) < 10 AND IS_NOT_NULL(CAST(a)) ==> (CAST(a) + 1) < 10
+    checkSimplifyFilter(
+        and(
+            lt(plus(cast(vVarchar(), tDouble(true)), literal(1)), literal(10)),
+            isNotNull(cast(vVarchar(), tDouble(true)))),
+        "<(+(CAST(?0.varchar0):DOUBLE, 1), 10)");
+
+    // safe cast: (CAST(a) + 1) < 10 AND IS_NOT_NULL(CAST(a)) ==> (CAST(a) + 1) < 10
+    checkSimplifyFilter(
+        and(
+            lt(plus(cast(vInt(), tDouble(true)), literal(1)), literal(10)),
+            isNotNull(cast(vInt(), tDouble(true)))),
+        "<(+(CAST(?0.int0):DOUBLE, 1), 10)");
+
+    // op that can return NULL on non-NULL args:
+    // IS_NOT_NULL(REGEXP_SUBSTR(myField, '[xw]yz')) AND REGEXP_SUBSTR(myField, '[xw]yz') = 'xyz'
+    // ==> REGEXP_SUBSTR(myField, '[xw]yz') = 'xyz'
+    checkSimplifyFilter(
+        and(
+            isNotNull(
+                rexBuilder.makeCall(
+                SqlLibraryOperators.REGEXP_SUBSTR, vVarchar(), literal("[xw]yz"))),
+            eq(
+                rexBuilder.makeCall(
+                    SqlLibraryOperators.REGEXP_SUBSTR, vVarchar(), literal("[xw]yz")),
+                literal("xyz"))),
+        "=(REGEXP_SUBSTR(?0.varchar0, '[xw]yz'), 'xyz')");
   }
 
   /**


### PR DESCRIPTION

<!--
Thanks for sending a pull request! Here are some critical tips for you:

1. READ THE GUIDE FIRST: https://calcite.apache.org/develop/#contributing
   *For significant contributions, please discuss on the dev mailing list or Jira BEFORE coding.*

2. JIRA IS USUALLY MANDATORY: Ensure you have created an issue on the Calcite Jira:
   https://issues.apache.org/jira/projects/CALCITE/issues
   *Check existing issues first to avoid duplicates.*
   *Note: A Jira is NOT required for typos and cosmetic changes (i.e., changes that are neither bugs nor features).*

3. TIMING: Strongly recommended to create the Jira BEFORE you start writing code (e.g., a day or so before posting a PR).
   This gives others a chance to weigh in on your specification.

4. CRITICAL CONSISTENCY RULE
   The following three items MUST match exactly in wording and meaning:
   (A) The Jira Issue Title
   (B) This Pull Request Title
   (C) Your Git Commit Message

   Format: [CALCITE-XXXX] <Description>
   Example: [CALCITE-0000] Add IF NOT EXISTS clause to CREATE TABLE

   Guidelines for a good Title:
   - Illustrate using SQL keywords (in ALL-CAPS) rather than Java method names.
   - Focus on the specification and user experience, not the implementation.
   - Make it clear whether it is a bug or a feature.
   - Use words like "should" to indicate desired behavior vs. current behavior (e.g., "Validator should not close model file").

5. REPRODUCTION: If fixing a bug, please provide a concise SQL example or test case to reproduce the issue for a faster review.

6. TESTING: Ensure `./gradlew build` passes and appropriate tests are added/updated.
-->

## Jira Link

[CALCITE-7758](https://issues.apache.org/jira/browse/CALCITE-7758)

## Changes Proposed
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.
-->
Improve RexSimplify to remove redundant IS_NOT_NULL on expressions that are other then RexInputRef or RexFieldAccess, e.g.:

```
IS_NOT_NULL(CAST(a)) AND (CAST(a) + 1) < 10 
=>
(CAST(a) + 1) < 10 
```