### PR TITLE
SEMI JOIN should not duplicate a singleton left row

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/SingleValuesOptimizationRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/SingleValuesOptimizationRules.java
@@ -284,8 +284,10 @@ public abstract class SingleValuesOptimizationRules {
           || jn.getJoinType() == JoinRelType.FULL;
 
       if (isLeft) {
+        // A semi join must emit the left row only once, even if several right rows match.
         return jn -> !(jn.getJoinType() == JoinRelType.LEFT
             || jn.getJoinType() == JoinRelType.LEFT_MARK
+            || jn.getJoinType() == JoinRelType.SEMI
             || isFullOrAntiJoin.test(jn));
       } else {
         return jn -> !(jn.getJoinType() == JoinRelType.RIGHT || isFullOrAntiJoin.test(jn));

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -5625,6 +5625,27 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  @Test void testSemiJoinWithConstantRowOnLeft() {
+    relFn(builder -> builder
+        .values(new String[]{"l"}, 1)
+        .values(new String[]{"r"}, 1, 1)
+        .semiJoin(builder.equals(builder.field(2, 0, 0), builder.field(2, 1, 0)))
+        .build())
+        .withRule(SingleValuesOptimizationRules.JOIN_LEFT_INSTANCE)
+        .checkUnchanged();
+  }
+
+  @Test void testSemiJoinWithProjectOnConstantRowOnLeft() {
+    relFn(builder -> builder
+        .values(new String[]{"l"}, 1)
+        .projectPlus(builder.call(SqlStdOperatorTable.CURRENT_TIMESTAMP))
+        .values(new String[]{"r"}, 1, 1)
+        .semiJoin(builder.equals(builder.field(2, 0, 0), builder.field(2, 1, 0)))
+        .build())
+        .withRule(SingleValuesOptimizationRules.JOIN_LEFT_PROJECT_INSTANCE)
+        .checkUnchanged();
+  }
+
   @Test void testRightJoinWithConstantRowOnLeft() {
     final String sql = "select e.empno, e.ename, c.*"
         + " from (select 5 as nm) c right join emp e on e.empno = c.nm";

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -18938,6 +18938,25 @@ LogicalProject(DEPTNO=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testSemiJoinWithConstantRowOnLeft">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalJoin(condition=[=($0, $1)], joinType=[semi])
+  LogicalValues(tuples=[[{ 1 }]])
+  LogicalValues(tuples=[[{ 1 }, { 1 }]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSemiJoinWithProjectOnConstantRowOnLeft">
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalJoin(condition=[=($0, $2)], joinType=[semi])
+  LogicalProject(l=[$0], $f1=[CURRENT_TIMESTAMP])
+    LogicalValues(tuples=[[{ 1 }]])
+  LogicalValues(tuples=[[{ 1 }, { 1 }]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSimplifyFilter">
     <Resource name="sql">
       <![CDATA[select * from (select * from sales.emp where deptno > 10)


### PR DESCRIPTION
## Jira Link

Pending issue creation and linkage. This PR is a draft.

## Changes Proposed

A SEMI JOIN with a singleton left input currently becomes a filter and projection over the right input. If several right rows match, the rewrite returns the left row once per match instead of once overall.

Exclude SEMI joins from the left-singleton simplification, including the Project-over-Values variant. Add regressions for both shapes. Right-singleton SEMI joins retain their existing optimization.

## Reproduction

Join left `VALUES (1)` to right `VALUES (1), (1)` with a SEMI equality join. The original join returns one row; the affected rewrite returns two.

```sh
./gradlew :core:test --tests 'org.apache.calcite.test.RelOptRulesTest.testSemiJoinWithConstantRowOnLeft' --tests 'org.apache.calcite.test.RelOptRulesTest.testSemiJoinWithProjectOnConstantRowOnLeft'
```

## Validation

- A compiled-source HepPlanner/Interpreter reproduction returns two rows before the fix and one after, for both left-side rule variants.
- Both right-side rule variants still optimize and preserve their results.
- Both exact planner regression methods pass against the checked-in XML snapshots and fail against the baseline rule.
- `./gradlew autostyleApply` and `git diff --check` pass.
- Focused runs used freshly compiled changed classes with cached supporting artifacts. Native Gradle test-class compilation on pristine `main` was blocked by `java.io.IOException: No space left on device`; the full Gradle build has not been validated locally.

## Downsides

This disables the invalid simplification for left-singleton SEMI joins. A separate existence-preserving rewrite could recover that optimization later.
