### PR TITLE
Merge ANTI JOIN should preserve unmatched NULL keys

### DIFF
--- a/core/src/test/java/org/apache/calcite/runtime/EnumerablesTest.java
+++ b/core/src/test/java/org/apache/calcite/runtime/EnumerablesTest.java
@@ -192,30 +192,35 @@ class EnumerablesTest {
         newArrayList(1, 3, 4),
         newArrayList(1, 4),
         equalTo("[3]"),
+        equalTo("[3, null]"),
         JoinType.ANTI);
     // Matching key at start and end of right, not of left
     testIntersect(
         newArrayList(0, 1, 3, 4, 5),
         newArrayList(1, 4),
         equalTo("[0, 3, 5]"),
+        equalTo("[0, 3, 5, null]"),
         JoinType.ANTI);
     // Matching key at start and end of left, not right
     testIntersect(
         newArrayList(1, 3, 4),
         newArrayList(0, 1, 4, 5),
         equalTo("[3]"),
+        equalTo("[3, null]"),
         JoinType.ANTI);
     // Matching key not at start or end of left or right
     testIntersect(
         newArrayList(0, 2, 3, 4, 5),
         newArrayList(1, 3, 4, 6),
         equalTo("[0, 2, 5]"),
+        equalTo("[0, 2, 5, null]"),
         JoinType.ANTI);
     // Matching duplicated keys
     testIntersect(
         newArrayList(1, 3, 4),
         newArrayList(1, 1, 4, 4),
         equalTo("[3]"),
+        equalTo("[3, null]"),
         JoinType.ANTI);
 
     // LEFT join tests:
@@ -291,24 +296,28 @@ class EnumerablesTest {
         newArrayList(0, 2, 4),
         newArrayList(1, 3, 5),
         equalTo("[0, 2, 4]"),
+        equalTo("[0, 2, 4, null]"),
         JoinType.ANTI);
     // Left empty
     testIntersect(
         new ArrayList<>(),
         newArrayList(1, 3, 4, 6),
         equalTo("[]"),
+        equalTo("[null]"),
         JoinType.ANTI);
     // Right empty
     testIntersect(
         newArrayList(3, 7),
         new ArrayList<>(),
         equalTo("[3, 7]"),
+        equalTo("[3, 7, null]"),
         JoinType.ANTI);
     // Both empty
     testIntersect(
         new ArrayList<Integer>(),
         new ArrayList<>(),
         equalTo("[]"),
+        equalTo("[null]"),
         JoinType.ANTI);
 
     // LEFT join tests:
@@ -340,6 +349,21 @@ class EnumerablesTest {
         equalTo("[]"),
         equalTo("[null-null]"),
         JoinType.LEFT);
+  }
+
+  @Test void testMergeAntiJoinWithRepeatedNullKeys() {
+    testIntersect(
+        newArrayList(1, 2, null, null),
+        newArrayList(1),
+        equalTo("[2, null, null]"),
+        equalTo("[2, null, null, null]"),
+        JoinType.ANTI);
+    testIntersect(
+        newArrayList(1, null, null),
+        newArrayList(1, 2),
+        equalTo("[null, null]"),
+        equalTo("[null, null, null]"),
+        JoinType.ANTI);
   }
 
   private static <T extends Comparable<T>> void testIntersect(
@@ -636,7 +660,8 @@ class EnumerablesTest {
             (v0, v1) -> v0,
             JoinType.ANTI,
             null, null).toList(),
-        hasToString("[Emp(30, Fred), Emp(20, Sebastian), Emp(20, Zoey)]"));
+        hasToString("[Emp(30, Fred), Emp(20, Sebastian), Emp(20, Zoey), "
+            + "Emp(40, null), Emp(30, null)]"));
   }
 
   @Test void testMergeLeftJoin() {

--- a/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
+++ b/linq4j/src/main/java/org/apache/calcite/linq4j/EnumerableDefaults.java
@@ -5047,11 +5047,11 @@ public abstract class EnumerableDefaults {
     }
 
     /** Returns whether the left enumerator was successfully advanced to the next
-     * element, and it does not have a null key (except for LEFT join, that needs to process
-     * all elements from left. */
+     * element, and it does not have a null key (except for LEFT and ANTI joins, which need to
+     * process all elements from left). */
     private boolean leftMoveNext() {
       return getLeftEnumerator().moveNext()
-          && (joinType == JoinType.LEFT
+          && (isLeftOrAntiJoin()
               || outerKeySelector.apply(getLeftEnumerator().current()) != null);
     }
 
@@ -5125,7 +5125,7 @@ public abstract class EnumerableDefaults {
           // mergeJoin assumes inputs sorted in ascending order with nulls last,
           // if we reach a null key, we are done.
           if (leftKey == null || rightKey == null) {
-            if (joinType == JoinType.LEFT || (joinType == JoinType.ANTI && leftKey != null)) {
+            if (isLeftOrAntiJoin()) {
               // all remaining items in left are results for left/anti join
               remainingLeft = true;
               return true;
@@ -5234,9 +5234,10 @@ public abstract class EnumerableDefaults {
       while (getLeftEnumerator().moveNext()) {
         left = getLeftEnumerator().current();
         TKey leftKey2 = outerKeySelector.apply(left);
-        if (leftKey2 == null && joinType != JoinType.LEFT) {
+        if (leftKey2 == null && !isLeftOrAntiJoin()) {
           // mergeJoin assumes inputs sorted in ascending order with nulls last,
-          // if we reach a null key, we are done (except LEFT join, that needs to process LHS fully)
+          // if we reach a null key, we are done (except LEFT and ANTI joins, which
+          // process LHS fully)
           break;
         }
         if (!compareEquals(leftKey, leftKey2)) {


### PR DESCRIPTION
## Jira Link

Pending issue creation and linkage. This PR is a draft.

## Changes Proposed

Enumerable merge ANTI joins currently stop processing left rows when they reach a NULL join key. Under strict equality, NULL keys do not match and those left rows must survive the ANTI join.

Preserve left NULL keys in all three merge-join advancement paths. Correct the existing ANTI test expectations and add repeated-NULL coverage. The tests also cover empty inputs, NULL keys on the right, and the overload with an additional predicate.

## Reproduction

With ascending, NULLS LAST inputs, an equality ANTI join of left `[1, 2, NULL]` and right `[1]` returns `[2]`. The correct result is `[2, NULL]`.

```sh
./gradlew :core:test --tests 'org.apache.calcite.runtime.EnumerablesTest'
```

## Validation

- The updated test class fails in four methods against the baseline runtime.
- Compiling the changed runtime and running the complete `EnumerablesTest` class directly passes all 53 enabled tests; one existing test is disabled.
- Generated EnumerableMergeJoin execution returns `[2, NULL]` after the fix.
- `./gradlew autostyleApply` and `git diff --check` pass.
- Focused runs used freshly compiled changed classes with cached supporting artifacts. Native Gradle test-class compilation on pristine `main` was blocked by `java.io.IOException: No space left on device`; the full Gradle build has not been validated locally.
