### PR TITLE
[CALCITE-7084] JOINs with USING would fail when validator identifier expansion is disabled

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -4637,11 +4637,18 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
 
   private void checkRollUpInSelectList(SqlSelect select) {
     SqlValidatorScope scope = getSelectScope(select);
+    final SelectScope selectScope = getRawSelectScopeNonNull(select);
+    final Expander expander = new Expander(this, selectScope);
     for (SqlNode item : SqlNonNullableAccessors.getSelectList(select)) {
       if (SqlValidatorUtil.isMeasure(item)) {
         continue;
       }
-      checkRollUp(null, select, item, scope);
+      SqlNode expandedItem = expander.expandCommonColumn(select, item, selectScope);
+      if (expandedItem instanceof SqlCall
+          && ((SqlCall) expandedItem).getOperator() instanceof SqlAsOperator) {
+        expandedItem = ((SqlCall) expandedItem).operand(0);
+      }
+      checkRollUp(null, select, expandedItem, scope);
     }
   }
 

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -6237,6 +6237,20 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         .ok()
         .withConformance(SqlConformanceEnum.ORACLE_12)
         .ok();
+
+    // Unqualified common column in SELECT should succeed even when
+    // identifier expansion is disabled.
+    sql("select deptno from emp join dept using (deptno)")
+        .withValidatorIdentifierExpansion(true)
+        .ok();
+
+    sql("select deptno from emp join dept using (deptno)")
+        .withValidatorIdentifierExpansion(false)
+        .ok();
+
+    sql("select deptno from emp natural join dept")
+        .withValidatorIdentifierExpansion(false)
+        .ok();
   }
 
   /** Test case for


### PR DESCRIPTION
jira: http://issues.apache.org/jira/browse/CALCITE-7084