### PR TITLE
Temporarily disable some tests to enable Avatica to merge [CALCITE-7494]

### DIFF
--- a/babel/src/test/resources/sql/big-query.iq
+++ b/babel/src/test/resources/sql/big-query.iq
@@ -34,9 +34,21 @@
 
 # Test case for [CALCITE-7491] https://issues.apache.org/jira/browse/CALCITE-7491
 # Literals of type TIMESTAMP WITH TIME ZONE cause crashes
-# This will change once we fix [CALCITE-7494]
-# Avatica conversion to string of TIMESTAMP WITH TIME ZONE
-# does not include time zone
+# The rendering depends on [CALCITE-7494] Avatica conversion to string of
+# TIMESTAMP WITH TIME ZONE does not include time zone, fixed in Avatica 1.29.0
+!if (fixed.calcite7494) {
+select TIMESTAMP WITH TIME ZONE '2020-01-01 00:00:00 America/New_York';
++-------------------------+
+| EXPR$0                  |
++-------------------------+
+| 2020-01-01 05:00:00 UTC |
++-------------------------+
+(1 row)
+
+!ok
+!}
+
+!if (not.fixed.calcite7494) {
 select TIMESTAMP WITH TIME ZONE '2020-01-01 00:00:00 America/New_York';
 +---------------------+
 | EXPR$0              |
@@ -46,6 +58,7 @@ select TIMESTAMP WITH TIME ZONE '2020-01-01 00:00:00 America/New_York';
 (1 row)
 
 !ok
+!}
 
 # Two timestamps with time zone are equal if they represent the same UTC time
 SELECT TIMESTAMP WITH TIME ZONE '2020-01-01 08:10:10 America/New_York' = TIMESTAMP WITH TIME ZONE '2020-01-01 05:10:10 America/Los_Angeles';

--- a/babel/src/test/resources/sql/postgresql.iq
+++ b/babel/src/test/resources/sql/postgresql.iq
@@ -526,640 +526,644 @@ EXPR$0
 null
 !ok
 
+# [CALCITE-7494] Avatica 1.29.0 renders TIMESTAMP WITH TIME ZONE with its zone
+!if (fixed.calcite7494) {
+### disabled until Bug.CALCITE_7494_FIXED ###
 select to_timestamp('01', 'HH');
 EXPR$0
-0001-01-01 01:00:00
+0001-01-01 01:00:00 UTC
 !ok
 
 select to_timestamp('1', 'HH');
 EXPR$0
-0001-01-01 01:00:00
+0001-01-01 01:00:00 UTC
 !ok
 
 select to_timestamp('11', 'HH');
 EXPR$0
-0001-01-01 11:00:00
+0001-01-01 11:00:00 UTC
 !ok
 
 select to_timestamp('01', 'HH12');
 EXPR$0
-0001-01-01 01:00:00
+0001-01-01 01:00:00 UTC
 !ok
 
 select to_timestamp('1', 'HH12');
 EXPR$0
-0001-01-01 01:00:00
+0001-01-01 01:00:00 UTC
 !ok
 
 select to_timestamp('11', 'HH12');
 EXPR$0
-0001-01-01 11:00:00
+0001-01-01 11:00:00 UTC
 !ok
 
 select to_timestamp('01', 'HH24');
 EXPR$0
-0001-01-01 01:00:00
+0001-01-01 01:00:00 UTC
 !ok
 
 select to_timestamp('1', 'HH24');
 EXPR$0
-0001-01-01 01:00:00
+0001-01-01 01:00:00 UTC
 !ok
 
 select to_timestamp('18', 'HH24');
 EXPR$0
-0001-01-01 18:00:00
+0001-01-01 18:00:00 UTC
 !ok
 
 select to_timestamp('01', 'MI');
 EXPR$0
-0001-01-01 00:01:00
+0001-01-01 00:01:00 UTC
 !ok
 
 select to_timestamp('1', 'MI');
 EXPR$0
-0001-01-01 00:01:00
+0001-01-01 00:01:00 UTC
 !ok
 
 select to_timestamp('57', 'MI');
 EXPR$0
-0001-01-01 00:57:00
+0001-01-01 00:57:00 UTC
 !ok
 
 select to_timestamp('01', 'SS');
 EXPR$0
-0001-01-01 00:00:01
+0001-01-01 00:00:01 UTC
 !ok
 
 select to_timestamp('1', 'SS');
 EXPR$0
-0001-01-01 00:00:01
+0001-01-01 00:00:01 UTC
 !ok
 
 select to_timestamp('57', 'SS');
 EXPR$0
-0001-01-01 00:00:57
+0001-01-01 00:00:57 UTC
 !ok
 
 select to_timestamp('03AM', 'HH12AM');
 EXPR$0
-0001-01-01 03:00:00
+0001-01-01 03:00:00 UTC
 !ok
 
 select to_timestamp('03AM', 'HH12PM');
 EXPR$0
-0001-01-01 03:00:00
+0001-01-01 03:00:00 UTC
 !ok
 
 select to_timestamp('03PM', 'HH12AM');
 EXPR$0
-0001-01-01 15:00:00
+0001-01-01 15:00:00 UTC
 !ok
 
 select to_timestamp('03PM', 'HH12PM');
 EXPR$0
-0001-01-01 15:00:00
+0001-01-01 15:00:00 UTC
 !ok
 
 select to_timestamp('03A.M.', 'HH12A.M.');
 EXPR$0
-0001-01-01 03:00:00
+0001-01-01 03:00:00 UTC
 !ok
 
 select to_timestamp('03A.M.', 'HH12P.M.');
 EXPR$0
-0001-01-01 03:00:00
+0001-01-01 03:00:00 UTC
 !ok
 
 select to_timestamp('03P.M.', 'HH12A.M.');
 EXPR$0
-0001-01-01 15:00:00
+0001-01-01 15:00:00 UTC
 !ok
 
 select to_timestamp('03P.M.', 'HH12P.M.');
 EXPR$0
-0001-01-01 15:00:00
+0001-01-01 15:00:00 UTC
 !ok
 
 select to_timestamp('03am', 'HH12am');
 EXPR$0
-0001-01-01 03:00:00
+0001-01-01 03:00:00 UTC
 !ok
 
 select to_timestamp('03am', 'HH12pm');
 EXPR$0
-0001-01-01 03:00:00
+0001-01-01 03:00:00 UTC
 !ok
 
 select to_timestamp('03pm', 'HH12am');
 EXPR$0
-0001-01-01 15:00:00
+0001-01-01 15:00:00 UTC
 !ok
 
 select to_timestamp('03pm', 'HH12pm');
 EXPR$0
-0001-01-01 15:00:00
+0001-01-01 15:00:00 UTC
 !ok
 
 select to_timestamp('03a.m.', 'HH12a.m.');
 EXPR$0
-0001-01-01 03:00:00
+0001-01-01 03:00:00 UTC
 !ok
 
 select to_timestamp('03a.m.', 'HH12p.m.');
 EXPR$0
-0001-01-01 03:00:00
+0001-01-01 03:00:00 UTC
 !ok
 
 select to_timestamp('03p.m.', 'HH12a.m.');
 EXPR$0
-0001-01-01 15:00:00
+0001-01-01 15:00:00 UTC
 !ok
 
 select to_timestamp('03p.m.', 'HH12p.m.');
 EXPR$0
-0001-01-01 15:00:00
+0001-01-01 15:00:00 UTC
 !ok
 
 select to_timestamp('0,001', 'Y,YYY');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('2,024', 'Y,YYY');
 EXPR$0
-2024-01-01 00:00:00
+2024-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('0001', 'YYYY');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1', 'YYYY');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('2024', 'YYYY');
 EXPR$0
-2024-01-01 00:00:00
+2024-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('001', 'YYY');
 EXPR$0
-2001-01-01 00:00:00
+2001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1', 'YYY');
 EXPR$0
-2001-01-01 00:00:00
+2001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('987', 'YYY');
 EXPR$0
-1987-01-01 00:00:00
+1987-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('01', 'YY');
 EXPR$0
-2001-01-01 00:00:00
+2001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1', 'YY');
 EXPR$0
-2001-01-01 00:00:00
+2001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('24', 'YY');
 EXPR$0
-2024-01-01 00:00:00
+2024-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1', 'Y');
 EXPR$0
-2001-01-01 00:00:00
+2001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('4', 'YY');
 EXPR$0
-2004-01-01 00:00:00
+2004-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('0001', 'IYYY');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1', 'IYYY');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('2024', 'IYYY');
 EXPR$0
-2024-01-01 00:00:00
+2024-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('001', 'IYY');
 EXPR$0
-2001-01-01 00:00:00
+2001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1', 'IYY');
 EXPR$0
-2001-01-01 00:00:00
+2001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('987', 'IYY');
 EXPR$0
-1987-01-01 00:00:00
+1987-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('01', 'IY');
 EXPR$0
-2001-01-01 00:00:00
+2001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1', 'IY');
 EXPR$0
-2001-01-01 00:00:00
+2001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('24', 'IY');
 EXPR$0
-2024-01-01 00:00:00
+2024-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1', 'I');
 EXPR$0
-2001-01-01 00:00:00
+2001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('4', 'I');
 EXPR$0
-2004-01-01 00:00:00
+2004-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('JANUARY', 'MONTH');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('MARCH', 'MONTH');
 EXPR$0
-0001-03-01 00:00:00
+0001-03-01 00:00:00 UTC
 !ok
 
 select to_timestamp('NOVEMBER', 'MONTH');
 EXPR$0
-0001-11-01 00:00:00
+0001-11-01 00:00:00 UTC
 !ok
 
 select to_timestamp('January', 'Month');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('March', 'Month');
 EXPR$0
-0001-03-01 00:00:00
+0001-03-01 00:00:00 UTC
 !ok
 
 select to_timestamp('November', 'Month');
 EXPR$0
-0001-11-01 00:00:00
+0001-11-01 00:00:00 UTC
 !ok
 
 select to_timestamp('january', 'month');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('march', 'month');
 EXPR$0
-0001-03-01 00:00:00
+0001-03-01 00:00:00 UTC
 !ok
 
 select to_timestamp('november', 'month');
 EXPR$0
-0001-11-01 00:00:00
+0001-11-01 00:00:00 UTC
 !ok
 
 select to_timestamp('JAN', 'MON');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('MAR', 'MON');
 EXPR$0
-0001-03-01 00:00:00
+0001-03-01 00:00:00 UTC
 !ok
 
 select to_timestamp('NOV', 'MON');
 EXPR$0
-0001-11-01 00:00:00
+0001-11-01 00:00:00 UTC
 !ok
 
 select to_timestamp('Jan', 'Mon');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('Mar', 'Mon');
 EXPR$0
-0001-03-01 00:00:00
+0001-03-01 00:00:00 UTC
 !ok
 
 select to_timestamp('Nov', 'Mon');
 EXPR$0
-0001-11-01 00:00:00
+0001-11-01 00:00:00 UTC
 !ok
 
 select to_timestamp('jan', 'mon');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('mar', 'mon');
 EXPR$0
-0001-03-01 00:00:00
+0001-03-01 00:00:00 UTC
 !ok
 
 select to_timestamp('nov', 'mon');
 EXPR$0
-0001-11-01 00:00:00
+0001-11-01 00:00:00 UTC
 !ok
 
 select to_timestamp('01', 'MM');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1', 'MM');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('11', 'MM');
 EXPR$0
-0001-11-01 00:00:00
+0001-11-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 MONDAY', 'IYYY IW DAY');
 EXPR$0
-1982-06-07 00:00:00
+1982-06-07 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 THURSDAY', 'IYYY IW DAY');
 EXPR$0
-1982-06-10 00:00:00
+1982-06-10 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 FRIDAY', 'IYYY IW DAY');
 EXPR$0
-1982-06-11 00:00:00
+1982-06-11 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 Monday', 'IYYY IW Day');
 EXPR$0
-1982-06-07 00:00:00
+1982-06-07 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 Thursday', 'IYYY IW Day');
 EXPR$0
-1982-06-10 00:00:00
+1982-06-10 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 Friday', 'IYYY IW Day');
 EXPR$0
-1982-06-11 00:00:00
+1982-06-11 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 monday', 'IYYY IW day');
 EXPR$0
-1982-06-07 00:00:00
+1982-06-07 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 thursday', 'IYYY IW day');
 EXPR$0
-1982-06-10 00:00:00
+1982-06-10 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 friday', 'IYYY IW day');
 EXPR$0
-1982-06-11 00:00:00
+1982-06-11 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 MON', 'IYYY IW DY');
 EXPR$0
-1982-06-07 00:00:00
+1982-06-07 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 THU', 'IYYY IW DY');
 EXPR$0
-1982-06-10 00:00:00
+1982-06-10 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 FRI', 'IYYY IW DY');
 EXPR$0
-1982-06-11 00:00:00
+1982-06-11 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 Mon', 'IYYY IW Dy');
 EXPR$0
-1982-06-07 00:00:00
+1982-06-07 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 Thu', 'IYYY IW Dy');
 EXPR$0
-1982-06-10 00:00:00
+1982-06-10 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 Fri', 'IYYY IW Dy');
 EXPR$0
-1982-06-11 00:00:00
+1982-06-11 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 mon', 'IYYY IW dy');
 EXPR$0
-1982-06-07 00:00:00
+1982-06-07 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 thu', 'IYYY IW dy');
 EXPR$0
-1982-06-10 00:00:00
+1982-06-10 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 fri', 'IYYY IW dy');
 EXPR$0
-1982-06-11 00:00:00
+1982-06-11 00:00:00 UTC
 !ok
 
 select to_timestamp('2024 001', 'YYYY DDD');
 EXPR$0
-2024-01-01 00:00:00
+2024-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('2024 1', 'YYYY DDD');
 EXPR$0
-2024-01-01 00:00:00
+2024-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('2024 137', 'YYYY DDD');
 EXPR$0
-2024-05-16 00:00:00
+2024-05-16 00:00:00 UTC
 !ok
 
 select to_timestamp('01', 'DD');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1', 'DD');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('23', 'DD');
 EXPR$0
-0001-01-23 00:00:00
+0001-01-23 00:00:00 UTC
 !ok
 
 select to_timestamp('2020 001', 'IYYY IDDD');
 EXPR$0
-2019-12-30 00:00:00
+2019-12-30 00:00:00 UTC
 !ok
 
 select to_timestamp('2020 1', 'IYYY IDDD');
 EXPR$0
-2019-12-30 00:00:00
+2019-12-30 00:00:00 UTC
 !ok
 
 select to_timestamp('2020 137', 'IYYY IDDD');
 EXPR$0
-2020-05-14 00:00:00
+2020-05-14 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 1', 'IYYY IW ID');
 EXPR$0
-1982-06-07 00:00:00
+1982-06-07 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 4', 'IYYY IW ID');
 EXPR$0
-1982-06-10 00:00:00
+1982-06-10 00:00:00 UTC
 !ok
 
 select to_timestamp('1982 23 5', 'IYYY IW ID');
 EXPR$0
-1982-06-11 00:00:00
+1982-06-11 00:00:00 UTC
 !ok
 
 select to_timestamp('2024 1 1', 'YYYY MM W');
 EXPR$0
-2024-01-01 00:00:00
+2024-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('2024 4 2', 'YYYY MM W');
 EXPR$0
-2024-04-08 00:00:00
+2024-04-08 00:00:00 UTC
 !ok
 
 select to_timestamp('2024 11 4', 'YYYY MM W');
 EXPR$0
-2024-11-22 00:00:00
+2024-11-22 00:00:00 UTC
 !ok
 
 select to_timestamp('2024 01', 'YYYY WW');
 EXPR$0
-2024-01-01 00:00:00
+2024-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('2024 1', 'YYYY WW');
 EXPR$0
-2024-01-01 00:00:00
+2024-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('2024 51', 'YYYY WW');
 EXPR$0
-2024-12-16 00:00:00
+2024-12-16 00:00:00 UTC
 !ok
 
 select to_timestamp('2020 01', 'IYYY IW');
 EXPR$0
-2019-12-30 00:00:00
+2019-12-30 00:00:00 UTC
 !ok
 
 select to_timestamp('2020 1', 'IYYY IW');
 EXPR$0
-2019-12-30 00:00:00
+2019-12-30 00:00:00 UTC
 !ok
 
 select to_timestamp('2020 51', 'IYYY IW');
 EXPR$0
-2020-12-14 00:00:00
+2020-12-14 00:00:00 UTC
 !ok
 
 select to_timestamp('21', 'CC');
 EXPR$0
-2001-01-01 00:00:00
+2001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('16', 'CC');
 EXPR$0
-1501-01-01 00:00:00
+1501-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('1', 'CC');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('2460311', 'J');
 EXPR$0
-2024-01-01 00:00:00
+2024-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('2445897', 'J');
 EXPR$0
-1984-07-15 00:00:00
+1984-07-15 00:00:00 UTC
 !ok
 
 select to_timestamp('1806606', 'J');
 EXPR$0
-0234-03-21 00:00:00
+0234-03-21 00:00:00 UTC
 !ok
 
 select to_timestamp('I', 'RM');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('IV', 'RM');
 EXPR$0
-0001-04-01 00:00:00
+0001-04-01 00:00:00 UTC
 !ok
 
 select to_timestamp('IX', 'RM');
 EXPR$0
-0001-09-01 00:00:00
+0001-09-01 00:00:00 UTC
 !ok
 
 select to_timestamp('i', 'rm');
 EXPR$0
-0001-01-01 00:00:00
+0001-01-01 00:00:00 UTC
 !ok
 
 select to_timestamp('iv', 'rm');
 EXPR$0
-0001-04-01 00:00:00
+0001-04-01 00:00:00 UTC
 !ok
 
 select to_timestamp('ix', 'rm');
 EXPR$0
-0001-09-01 00:00:00
+0001-09-01 00:00:00 UTC
 !ok
+!}
 
 select to_date('2022-06-03', 'YYYY-MM-DD');
 EXPR$0
@@ -1241,15 +1245,19 @@ EXPR$0
 0001-01-01
 !ok
 
+# [CALCITE-7494] Avatica 1.29.0 renders TIMESTAMP WITH TIME ZONE with its zone
+!if (fixed.calcite7494) {
+### disabled until Bug.CALCITE_7494_FIXED ###
 select to_timestamp('18:46:32 2022-06-03', 'HH24:MI:SS YYYY-MM-DD');
 EXPR$0
-2022-06-03 18:46:32
+2022-06-03 18:46:32 UTC
 !ok
 
 select to_timestamp('18:46:32 Jun 03, 2022', 'HH24:MI:SS Mon DD, YYYY');
 EXPR$0
-2022-06-03 18:46:32
+2022-06-03 18:46:32 UTC
 !ok
+!}
 
 select date_part('microsecond', timestamp '2022-06-03 12:15:48.678');
 EXPR$0

--- a/core/src/main/java/org/apache/calcite/util/Bug.java
+++ b/core/src/main/java/org/apache/calcite/util/Bug.java
@@ -185,6 +185,13 @@ public abstract class Bug {
    * is fixed. */
   public static final boolean CALCITE_6611_FIXED = false;
 
+  /** Whether
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7494">[CALCITE-7494]
+   * Avatica conversion to string of TIMESTAMP WITH TIME ZONE does not include
+   * time zone</a> is fixed.
+   * Fix to be available with Avatica 1.29.0. */
+  public static final boolean CALCITE_7494_FIXED = false;
+
   /**
    * Use this to flag temporary code.
    */

--- a/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/QuidemTest.java
@@ -171,6 +171,8 @@ public abstract class QuidemTest {
           return Bug.CALCITE_1045_FIXED;
         case "calcite1048":
           return Bug.CALCITE_1048_FIXED;
+        case "calcite7494":
+          return Bug.CALCITE_7494_FIXED;
         }
         return null;
       };

--- a/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
+++ b/testkit/src/main/java/org/apache/calcite/test/SqlOperatorTest.java
@@ -5914,23 +5914,25 @@ public class SqlOperatorTest {
     final SqlOperatorFixture f = fixture().withLibrary(SqlLibrary.POSTGRESQL)
         .setFor(SqlLibraryOperators.TO_TIMESTAMP_PG);
 
+    // [CALCITE-7494] Avatica 1.29.0 appends the zone to TIMESTAMP WITH TIME ZONE
+    final String tz = Bug.CALCITE_7494_FIXED ? " UTC" : "";
     f.checkString("to_timestamp('2022-06-03 18:34:56', 'YYYY-MM-DD HH24:MI:SS')",
-        "2022-06-03 18:34:56",
+        "2022-06-03 18:34:56" + tz,
         "TIMESTAMP_TZ(0) NOT NULL");
     f.checkString("to_timestamp('0001-01-01 18:43:56', 'YYYY-MM-DD HH24:MI:SS')",
-        "0001-01-01 18:43:56",
+        "0001-01-01 18:43:56" + tz,
         "TIMESTAMP_TZ(0) NOT NULL");
     f.checkString("to_timestamp('18:34:56 Jun 03, 2022', 'HH24:MI:SS Mon DD, YYYY')",
-        "2022-06-03 18:34:56",
+        "2022-06-03 18:34:56" + tz,
         "TIMESTAMP_TZ(0) NOT NULL");
     f.checkString("to_timestamp('18:34:56 2022-June-03', 'HH24:MI:SS YYYY-Month-DD')",
-        "2022-06-03 18:34:56",
+        "2022-06-03 18:34:56" + tz,
         "TIMESTAMP_TZ(0) NOT NULL");
     f.checkString("to_timestamp('18:34:56 2022-Jun-03', 'HH24:MI:SS YYYY-Mon-DD')",
-        "2022-06-03 18:34:56",
+        "2022-06-03 18:34:56" + tz,
         "TIMESTAMP_TZ(0) NOT NULL");
     f.checkString("to_timestamp('18:34:56 2022-154', 'HH24:MI:SS YYYY-DDD')",
-        "2022-06-03 18:34:56",
+        "2022-06-03 18:34:56" + tz,
         "TIMESTAMP_TZ(0) NOT NULL");
     f.checkFails("to_timestamp('ABCD', 'YYYY-MM-DD HH24:MI:SS')",
         "java.sql.SQLException: Invalid format: 'YYYY-MM-DD HH24:MI:SS' for timestamp "


### PR DESCRIPTION
## Jira Link

[CALCITE-7494](https://issues.apache.org/jira/browse/CALCITE-7494)

## Changes Proposed

This PR disables some tests whose expected values will change once Avatica merges [CALCITE-7494]. The plan is to re-enable these tests once Avatica 1.29 is released and Calcite picks up that dependency we can re-enable these tests.