### PR TITLE
[CALCITE-7768] SqlDialect has no way to unparse a UUID literal

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlDialect.java
@@ -579,6 +579,15 @@ public class SqlDialect {
       SqlNodeList hints, int leftPrec, int rightPrec) {
   }
 
+  /** Converts a UUID literal to a SQL string. The default implementation
+   * returns strings such as
+   * <code>UUID '123e4567-e89b-12d3-a456-426655440000'</code>. A dialect whose
+   * product spells it differently should override this method. */
+  public void unparseUuidLiteral(SqlWriter writer,
+      SqlUuidLiteral literal, int leftPrec, int rightPrec) {
+    writer.literal(literal.toString());
+  }
+
   /**
    * Returns whether the string contains any characters outside the
    * comfortable 7-bit ASCII range (32 through 127, plus linefeed (10) and

--- a/core/src/main/java/org/apache/calcite/sql/SqlUuidLiteral.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlUuidLiteral.java
@@ -58,6 +58,6 @@ public class SqlUuidLiteral extends SqlLiteral {
       SqlWriter writer,
       int leftPrec,
       int rightPrec) {
-    writer.literal(this.toString());
+    writer.getDialect().unparseUuidLiteral(writer, this, leftPrec, rightPrec);
   }
 }

--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -38,6 +38,7 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlUtil;
+import org.apache.calcite.sql.SqlUuidLiteral;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -197,6 +198,11 @@ public class MssqlSqlDialect extends SqlDialect {
 
   @Override public void unparseDateTimeLiteral(SqlWriter writer,
       SqlAbstractDateTimeLiteral literal, int leftPrec, int rightPrec) {
+    writer.literal("'" + literal.toFormattedString() + "'");
+  }
+
+  @Override public void unparseUuidLiteral(SqlWriter writer,
+      SqlUuidLiteral literal, int leftPrec, int rightPrec) {
     writer.literal("'" + literal.toFormattedString() + "'");
   }
 

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -10988,6 +10988,15 @@ class RelToSqlConverterTest {
     sql(sql).ok(expected);
   }
 
+  /** Test case for <a href="https://issues.apache.org/jira/browse/CALCITE-7768">[CALCITE-7768]
+   * SqlDialect has no way to unparse a UUID literal</a>. */
+  @Test void testUuidMssql() {
+    final String sql = "SELECT UUID '123e4567-e89b-12d3-a456-426655440000' AS x";
+    final String expected = "SELECT *\n"
+        + "FROM (VALUES ('123e4567-e89b-12d3-a456-426655440000')) AS [t] ([X])";
+    sql(sql).withMssql().ok(expected);
+  }
+
   @Test void testUpdate() {
     final String sql0 = "update \"foodmart\".\"product\"\n"
         + "set \"product_name\" = 'calcite'";


### PR DESCRIPTION
## Jira Link

[CALCITE-7768](https://issues.apache.org/jira/browse/CALCITE-7768)

## Changes Proposed

A dialect can now decide how a UUID literal is written. The default output is unchanged, so only MSSQL is affected: it writes a plain quoted string, which SQL Server accepts.
