### PR TITLE
[CALCITE-7762] DateRangeRules may produce incorrect ranges, hang, or excessively expand sub-day predicates

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/rules/DateRangeRules.java
+++ b/core/src/main/java/org/apache/calcite/rel/rules/DateRangeRules.java
@@ -100,12 +100,16 @@ public abstract class DateRangeRules {
           .as(FilterDateRangeRule.FilterDateRangeRuleConfig.class)
           .toRule();
 
+  /** Default maximum number of matching ranges that may be enumerated while
+   * rewriting lower time-unit {@code EXTRACT} calls in one expression. */
+  public static final int DEFAULT_MAX_RANGE_COUNT = 100;
+
   private static final Map<TimeUnitRange, Integer> TIME_UNIT_CODES =
       ImmutableMap.<TimeUnitRange, Integer>builder()
           .put(TimeUnitRange.YEAR, Calendar.YEAR)
           .put(TimeUnitRange.MONTH, Calendar.MONTH)
           .put(TimeUnitRange.DAY, Calendar.DAY_OF_MONTH)
-          .put(TimeUnitRange.HOUR, Calendar.HOUR)
+          .put(TimeUnitRange.HOUR, Calendar.HOUR_OF_DAY)
           .put(TimeUnitRange.MINUTE, Calendar.MINUTE)
           .put(TimeUnitRange.SECOND, Calendar.SECOND)
           .put(TimeUnitRange.MILLISECOND, Calendar.MILLISECOND)
@@ -149,7 +153,19 @@ public abstract class DateRangeRules {
   @VisibleForTesting
   public static RexNode replaceTimeUnits(RexBuilder rexBuilder, RexNode e,
       String timeZone) {
-    e = RexUtil.expandSearch(rexBuilder, null, e);
+    return replaceTimeUnits(rexBuilder, e, timeZone, DEFAULT_MAX_RANGE_COUNT);
+  }
+
+  /** Replaces calls to EXTRACT, FLOOR and CEIL in an expression, limiting the
+   * number of ranges enumerated for lower time units. A limit of -1 allows
+   * unlimited ranges. */
+  @VisibleForTesting
+  static RexNode replaceTimeUnits(RexBuilder rexBuilder, RexNode e,
+      String timeZone, int maxRangeCount) {
+    assert maxRangeCount >= -1;
+    // RexUtil expands a SEARCH only if its complexity is strictly less than
+    // the limit. Add one so maxRangeCount remains inclusive.
+    e = RexUtil.expandSearch(rexBuilder, null, e, maxRangeCount + 1);
     ImmutableSortedSet<TimeUnitRange> timeUnits = extractTimeUnits(e);
     if (!timeUnits.contains(TimeUnitRange.YEAR)) {
       // Case when we have FLOOR or CEIL but no extract on YEAR.
@@ -159,11 +175,13 @@ public abstract class DateRangeRules {
           .addAll(timeUnits).add(TimeUnitRange.YEAR).build();
     }
     final Map<RexNode, RangeSet<Calendar>> operandRanges = new HashMap<>();
+    final RangeExpansionLimiter rangeExpansionLimiter =
+        new RangeExpansionLimiter(maxRangeCount);
     for (TimeUnitRange timeUnit : timeUnits) {
       e =
           e.accept(
               new ExtractShuttle(rexBuilder, timeUnit, operandRanges, timeUnits,
-                  timeZone));
+                  timeZone, rangeExpansionLimiter));
     }
     return e;
   }
@@ -206,7 +224,8 @@ public abstract class DateRangeRules {
       final String timeZone = filter.getCluster().getPlanner().getContext()
           .unwrapOrThrow(CalciteConnectionConfig.class).timeZone();
       final RexNode condition =
-          replaceTimeUnits(rexBuilder, filter.getCondition(), timeZone);
+          replaceTimeUnits(rexBuilder, filter.getCondition(), timeZone,
+              config.maxRangeCount());
       if (condition.equals(filter.getCondition())) {
         return;
       }
@@ -229,6 +248,16 @@ public abstract class DateRangeRules {
       @Override default FilterDateRangeRule toRule() {
         return new FilterDateRangeRule(this);
       }
+
+      /** Maximum number of matching ranges that may be enumerated while
+       * rewriting lower time-unit {@code EXTRACT} calls. A value of -1 allows
+       * unlimited ranges. */
+      @Value.Default default int maxRangeCount() {
+        return DEFAULT_MAX_RANGE_COUNT;
+      }
+
+      /** Sets {@link #maxRangeCount()}. */
+      FilterDateRangeRuleConfig withMaxRangeCount(int maxRangeCount);
     }
   }
 
@@ -274,6 +303,35 @@ public abstract class DateRangeRules {
     }
   }
 
+  /** Tracks the number of ranges generated while rewriting an expression. */
+  private static class RangeExpansionLimiter {
+    private final int maxRangeCount;
+    private int rangeCount;
+
+    RangeExpansionLimiter(int maxRangeCount) {
+      this.maxRangeCount = maxRangeCount;
+    }
+
+    int mark() {
+      return rangeCount;
+    }
+
+    boolean tryAddRange() {
+      if (maxRangeCount == -1) {
+        return true;
+      }
+      if (rangeCount >= maxRangeCount) {
+        return false;
+      }
+      ++rangeCount;
+      return true;
+    }
+
+    void reset(int rangeCount) {
+      this.rangeCount = rangeCount;
+    }
+  }
+
   /** Walks over an expression, replacing calls to
    * {@code EXTRACT}, {@code FLOOR} and {@code CEIL} with date ranges. */
   @VisibleForTesting
@@ -284,16 +342,27 @@ public abstract class DateRangeRules {
     private final Deque<RexCall> calls = new ArrayDeque<>();
     private final ImmutableSortedSet<TimeUnitRange> timeUnitRanges;
     private final String timeZone;
+    private final RangeExpansionLimiter rangeExpansionLimiter;
 
     @VisibleForTesting
     ExtractShuttle(RexBuilder rexBuilder, TimeUnitRange timeUnit,
         Map<RexNode, RangeSet<Calendar>> operandRanges,
         ImmutableSortedSet<TimeUnitRange> timeUnitRanges, String timeZone) {
+      this(rexBuilder, timeUnit, operandRanges, timeUnitRanges, timeZone,
+          new RangeExpansionLimiter(DEFAULT_MAX_RANGE_COUNT));
+    }
+
+    private ExtractShuttle(RexBuilder rexBuilder, TimeUnitRange timeUnit,
+        Map<RexNode, RangeSet<Calendar>> operandRanges,
+        ImmutableSortedSet<TimeUnitRange> timeUnitRanges, String timeZone,
+        RangeExpansionLimiter rangeExpansionLimiter) {
       this.rexBuilder = requireNonNull(rexBuilder, "rexBuilder");
       this.timeUnit = requireNonNull(timeUnit, "timeUnit");
       this.operandRanges = requireNonNull(operandRanges, "operandRanges");
       this.timeUnitRanges = requireNonNull(timeUnitRanges, "timeUnitRanges");
       this.timeZone = timeZone;
+      this.rangeExpansionLimiter =
+          requireNonNull(rangeExpansionLimiter, "rangeExpansionLimiter");
     }
 
     @Override public RexNode visitCall(RexCall call) {
@@ -314,7 +383,7 @@ public abstract class DateRangeRules {
             RexNode operand = subCall.getOperands().get(1);
             if (canRewriteExtract(operand)) {
               return compareExtract(call.getKind().reverse(), operand,
-                  (RexLiteral) op0);
+                  (RexLiteral) op0, call);
             }
           }
           if (isFloorCeilCall(op1)) {
@@ -341,7 +410,7 @@ public abstract class DateRangeRules {
             RexNode operand = subCall.operands.get(1);
             if (canRewriteExtract(operand)) {
               return compareExtract(call.getKind(),
-                  subCall.operands.get(1), (RexLiteral) op1);
+                  subCall.operands.get(1), (RexLiteral) op1, call);
             }
           }
           if (isFloorCeilCall(op0)) {
@@ -420,7 +489,7 @@ public abstract class DateRangeRules {
             clonedOperand =
                 clonedOperand.accept(
                     new ExtractShuttle(rexBuilder, timeUnit, operandRanges,
-                        timeUnitRanges, timeZone));
+                        timeUnitRanges, timeZone, rangeExpansionLimiter));
           }
           if ((clonedOperand != operand) && (update != null)) {
             update[0] = true;
@@ -449,12 +518,13 @@ public abstract class DateRangeRules {
     }
 
     RexNode compareExtract(SqlKind comparison, RexNode operand,
-        RexLiteral literal) {
+        RexLiteral literal, RexCall originalCall) {
       RangeSet<Calendar> rangeSet = operandRanges.get(operand);
       if (rangeSet == null) {
         rangeSet = ImmutableRangeSet.<Calendar>of().complement();
       }
       final RangeSet<Calendar> s2 = TreeRangeSet.create();
+      final int rangeCountMark = rangeExpansionLimiter.mark();
       // Calendar.MONTH is 0-based
       final int v = RexLiteral.intValue(literal)
           - (timeUnit == TimeUnitRange.MONTH ? 1 : 0);
@@ -482,6 +552,10 @@ public abstract class DateRangeRules {
             c = (Calendar) r.lowerEndpoint().clone();
             int i = 0;
             while (next(c, timeUnit, v, r, i++ > 0)) {
+              if (!rangeExpansionLimiter.tryAddRange()) {
+                rangeExpansionLimiter.reset(rangeCountMark);
+                return originalCall;
+              }
               s2.add(extractRange(timeUnit, comparison, c));
             }
           }
@@ -536,10 +610,10 @@ public abstract class DateRangeRules {
       case DAY:
         return v > 0 && v <= 31;
       case HOUR:
-        return v >= 0 && v <= 24;
+        return v >= 0 && v < 24;
       case MINUTE:
       case SECOND:
-        return v >= 0 && v <= 60;
+        return v >= 0 && v < 60;
       default:
         return false;
       }

--- a/core/src/test/java/org/apache/calcite/rel/rules/DateRangeRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rules/DateRangeRulesTest.java
@@ -17,7 +17,9 @@
 package org.apache.calcite.rel.rules;
 
 import org.apache.calcite.avatica.util.TimeUnitRange;
+import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.test.RexImplicationCheckerFixtures.Fixture;
 import org.apache.calcite.util.DateString;
@@ -35,6 +37,7 @@ import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.core.IsInstanceOf.any;
 
@@ -353,6 +356,125 @@ class DateRangeRulesTest {
             f.eq(f.exDayTs, f.literal(31))),
         is("AND(AND(>=($9, 2010-01-01 00:00:00), <($9, 2011-01-01 00:00:00)),"
             + " AND(>=($9, 2010-02-01 00:00:00), <($9, 2010-03-01 00:00:00)), false)"));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7762">[CALCITE-7762]
+   * DateRangeRules may produce incorrect ranges, hang, or excessively expand
+   * sub-day predicates</a>. */
+  @Test void testExtractHourFromTimestampColumn() {
+    final Fixture2 f = new Fixture2();
+    checkDateRange(f,
+        f.and(f.eq(f.exYearTs, f.literal(2010)),
+            f.eq(f.exMonthTs, f.literal(2)),
+            f.eq(f.exDayTs, f.literal(4)),
+            f.eq(f.exHourTs, f.literal(13))),
+        is("AND(AND(>=($9, 2010-01-01 00:00:00), <($9, 2011-01-01 00:00:00)),"
+            + " AND(>=($9, 2010-02-01 00:00:00), <($9, 2010-03-01 00:00:00)),"
+            + " AND(>=($9, 2010-02-04 00:00:00), <($9, 2010-02-05 00:00:00)),"
+            + " AND(>=($9, 2010-02-04 13:00:00), <($9, 2010-02-04 14:00:00)))"));
+
+    checkDateRange(f,
+        f.and(f.eq(f.exYearTs, f.literal(2010)),
+            f.eq(f.exHourTs, f.literal(24))),
+        is("AND(AND(>=($9, 2010-01-01 00:00:00), <($9, 2011-01-01 00:00:00)),"
+            + " false)"));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7762">[CALCITE-7762]
+   * DateRangeRules may produce incorrect ranges, hang, or excessively expand
+   * sub-day predicates</a>. */
+  @Test void testExtractInvalidMinuteAndSecond() {
+    final Fixture2 f = new Fixture2();
+    for (RexNode extract : ImmutableList.of(f.exMinuteTs, f.exSecondTs)) {
+      checkDateRange(f,
+          f.and(f.eq(f.exYearTs, f.literal(2010)),
+              f.eq(extract, f.literal(60))),
+          is("AND(AND(>=($9, 2010-01-01 00:00:00),"
+              + " <($9, 2011-01-01 00:00:00)), false)"));
+    }
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7762">[CALCITE-7762]
+   * DateRangeRules may produce incorrect ranges, hang, or excessively expand
+   * sub-day predicates</a>. */
+  @Test void testExtractRangeExpansionLimit() {
+    final Fixture2 f = new Fixture2();
+    final RexNode condition =
+        f.and(f.eq(f.exYearTs, f.literal(2010)),
+            f.eq(f.exDayTs, f.literal(31)));
+
+    final RexNode atLimit =
+        DateRangeRules.replaceTimeUnits(f.rexBuilder, condition, "UTC", 7);
+    final RexNode dayRanges = ((RexCall) atLimit).operands.get(1);
+    assertThat(((RexCall) dayRanges).operands, hasSize(7));
+
+    final RexNode overLimit =
+        DateRangeRules.replaceTimeUnits(f.rexBuilder, condition, "UTC", 6);
+    assertThat(overLimit,
+        hasToString("AND(AND(>=($9, 2010-01-01 00:00:00),"
+            + " <($9, 2011-01-01 00:00:00)), =(EXTRACT(FLAG(DAY), $9), 31))"));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7762">[CALCITE-7762]
+   * DateRangeRules may produce incorrect ranges, hang, or excessively expand
+   * sub-day predicates</a>. */
+  @Test void testSearchExpansionLimit() {
+    final Fixture2 f = new Fixture2();
+    final ImmutableList.Builder<RexNode> yearLiterals = ImmutableList.builder();
+    for (int year = 2000; year < 2100; ++year) {
+      yearLiterals.add(f.literal(year));
+    }
+    final RexNode searchAtLimit =
+        f.rexBuilder.makeIn(f.exYearTs, yearLiterals.build());
+    assertThat(searchAtLimit.getKind(), is(SqlKind.SEARCH));
+    final RexNode rewrittenAtLimit =
+        DateRangeRules.replaceTimeUnits(f.rexBuilder, searchAtLimit, "UTC");
+    assertThat(rewrittenAtLimit.getKind(), is(SqlKind.OR));
+    assertThat(((RexCall) rewrittenAtLimit).operands, hasSize(100));
+
+    yearLiterals.add(f.literal(2100));
+    final RexNode searchOverLimit =
+        f.rexBuilder.makeIn(f.exYearTs, yearLiterals.build());
+    assertThat(searchOverLimit.getKind(), is(SqlKind.SEARCH));
+    final RexNode rewrittenOverLimit =
+        DateRangeRules.replaceTimeUnits(f.rexBuilder, searchOverLimit, "UTC");
+    assertThat(rewrittenOverLimit, is(searchOverLimit));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7762">[CALCITE-7762]
+   * DateRangeRules may produce incorrect ranges, hang, or excessively expand
+   * sub-day predicates</a>. */
+  @Test void testExtractRangeExpansionUsesDefaultLimit() {
+    final Fixture2 f = new Fixture2();
+    final RexNode condition =
+        f.and(f.eq(f.exYearTs, f.literal(2010)),
+            f.eq(f.exHourTs, f.literal(13)));
+    final RexNode rewritten =
+        DateRangeRules.replaceTimeUnits(f.rexBuilder, condition, "UTC");
+    assertThat(rewritten,
+        hasToString("AND(AND(>=($9, 2010-01-01 00:00:00),"
+            + " <($9, 2011-01-01 00:00:00)), =(EXTRACT(FLAG(HOUR), $9), 13))"));
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7762">[CALCITE-7762]
+   * DateRangeRules may produce incorrect ranges, hang, or excessively expand
+   * sub-day predicates</a>. */
+  @Test void testExtractSecondRangeExpansionUsesDefaultLimit() {
+    final Fixture2 f = new Fixture2();
+    final RexNode condition =
+        f.and(f.eq(f.exYearTs, f.literal(2010)),
+            f.eq(f.exSecondTs, f.literal(15)));
+    final RexNode rewritten =
+        DateRangeRules.replaceTimeUnits(f.rexBuilder, condition, "UTC");
+    assertThat(rewritten,
+        hasToString("AND(AND(>=($9, 2010-01-01 00:00:00),"
+            + " <($9, 2011-01-01 00:00:00)), =(EXTRACT(FLAG(SECOND), $9), 15))"));
   }
 
   @Test void testUnboundYearExtractRewrite() {
@@ -739,6 +861,9 @@ class DateRangeRulesTest {
     private final RexNode exYearTs; // EXTRACT YEAR from TIMESTAMP field
     private final RexNode exMonthTs; // EXTRACT MONTH from TIMESTAMP field
     private final RexNode exDayTs; // EXTRACT DAY from TIMESTAMP field
+    private final RexNode exHourTs; // EXTRACT HOUR from TIMESTAMP field
+    private final RexNode exMinuteTs; // EXTRACT MINUTE from TIMESTAMP field
+    private final RexNode exSecondTs; // EXTRACT SECOND from TIMESTAMP field
     private final RexNode exYearD; // EXTRACT YEAR from DATE field
     private final RexNode exMonthD; // EXTRACT MONTH from DATE field
     private final RexNode exDayD; // EXTRACT DAY from DATE field
@@ -765,6 +890,15 @@ class DateRangeRulesTest {
       exDayTs =
           rexBuilder.makeCall(SqlStdOperatorTable.EXTRACT,
               ImmutableList.of(rexBuilder.makeFlag(TimeUnitRange.DAY), ts));
+      exHourTs =
+          rexBuilder.makeCall(SqlStdOperatorTable.EXTRACT,
+              ImmutableList.of(rexBuilder.makeFlag(TimeUnitRange.HOUR), ts));
+      exMinuteTs =
+          rexBuilder.makeCall(SqlStdOperatorTable.EXTRACT,
+              ImmutableList.of(rexBuilder.makeFlag(TimeUnitRange.MINUTE), ts));
+      exSecondTs =
+          rexBuilder.makeCall(SqlStdOperatorTable.EXTRACT,
+              ImmutableList.of(rexBuilder.makeFlag(TimeUnitRange.SECOND), ts));
       exYearD =
           rexBuilder.makeCall(SqlStdOperatorTable.EXTRACT,
               ImmutableList.of(rexBuilder.makeFlag(TimeUnitRange.YEAR), d));

--- a/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
+++ b/core/src/test/java/org/apache/calcite/test/RelOptRulesTest.java
@@ -10110,6 +10110,48 @@ class RelOptRulesTest extends RelOptTestBase {
         .check();
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7762">[CALCITE-7762]
+   * DateRangeRules may produce incorrect ranges, hang, or excessively expand
+   * sub-day predicates</a>. */
+  @Test void testFloorDayToRangeAfterNoon() {
+    final String sql = "select floor(hiredate to day) as d\n"
+        + "from sales.emp_b\n"
+        + "where floor(hiredate to day)"
+        + " < timestamp '2010-02-04 13:00:00'";
+    sql(sql).withRule(DateRangeRules.FILTER_INSTANCE)
+        .withContext(c -> Contexts.of(CalciteConnectionConfig.DEFAULT, c))
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7762">[CALCITE-7762]
+   * DateRangeRules may produce incorrect ranges, hang, or excessively expand
+   * sub-day predicates</a>. */
+  @Test void testCeilDayToRangeAfterNoon() {
+    final String sql = "select ceil(hiredate to day) as d\n"
+        + "from sales.emp_b\n"
+        + "where ceil(hiredate to day)"
+        + " < timestamp '2010-02-04 13:00:00'";
+    sql(sql).withRule(DateRangeRules.FILTER_INSTANCE)
+        .withContext(c -> Contexts.of(CalciteConnectionConfig.DEFAULT, c))
+        .check();
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7762">[CALCITE-7762]
+   * DateRangeRules may produce incorrect ranges, hang, or excessively expand
+   * sub-day predicates</a>. */
+  @Test void testExtractHourRangeExpansionIsBounded() {
+    final String sql = "select extract(hour from hiredate) as h\n"
+        + "from sales.emp_b\n"
+        + "where extract(year from hiredate) = 2010"
+        + " and extract(hour from hiredate) = 13";
+    sql(sql).withRule(DateRangeRules.FILTER_INSTANCE)
+        .withContext(c -> Contexts.of(CalciteConnectionConfig.DEFAULT, c))
+        .check();
+  }
+
   @Test void testFilterRemoveIsNotDistinctFromRule() {
     final Function<RelBuilder, RelNode> relFn = b -> b
         .scan("EMP")

--- a/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
+++ b/core/src/test/resources/org/apache/calcite/test/RelOptRulesTest.xml
@@ -2083,6 +2083,27 @@ LogicalProject(T=[CASE(<(CAST(CASE(>($1, 'abc'), $1, null:VARCHAR(20))):DOUBLE, 
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCeilDayToRangeAfterNoon">
+    <Resource name="sql">
+      <![CDATA[select ceil(hiredate to day) as d
+from sales.emp_b
+where ceil(hiredate to day) < timestamp '2010-02-04 13:00:00']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(D=[CEIL($4, FLAG(DAY))])
+  LogicalFilter(condition=[<(CEIL($4, FLAG(DAY)), 2010-02-04 13:00:00)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(D=[CEIL($4, FLAG(DAY))])
+  LogicalFilter(condition=[<=($4, 2010-02-04 00:00:00)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testChainJoinDphypJoinReorder">
     <Resource name="sql">
       <![CDATA[select emp.empno from emp, emp_address, dept, dept_nested where emp.deptno + emp_address.empno = dept.deptno + dept_nested.deptno and emp.empno = emp_address.empno and dept.deptno = dept_nested.deptno]]>
@@ -5943,6 +5964,27 @@ LogicalProject(BOOL_COL=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testExtractHourRangeExpansionIsBounded">
+    <Resource name="sql">
+      <![CDATA[select extract(hour from hiredate) as h
+from sales.emp_b
+where extract(year from hiredate) = 2010 and extract(hour from hiredate) = 13]]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(H=[EXTRACT(FLAG(HOUR), $4)])
+  LogicalFilter(condition=[AND(=(EXTRACT(FLAG(YEAR), $4), 2010), =(EXTRACT(FLAG(HOUR), $4), 13))])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(H=[EXTRACT(FLAG(HOUR), $4)])
+  LogicalFilter(condition=[AND(SEARCH($4, Sarg[[2010-01-01 00:00:00..2011-01-01 00:00:00)]), =(EXTRACT(FLAG(HOUR), $4), 13))])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testExtractJoinFilterRule">
     <Resource name="sql">
       <![CDATA[select 1 from emp inner join dept on emp.deptno=dept.deptno]]>
@@ -6524,6 +6566,27 @@ LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$
             LogicalFilter(condition=[=($cor0.DEPTNO, $9)])
               LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4], SAL=[$5], COMM=[$6], DEPTNO=[$7], SLACKER=[$8], $f9=[+(*(2, $7), 30)])
                 LogicalTableScan(table=[[CATALOG, SALES, EMP]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testFloorDayToRangeAfterNoon">
+    <Resource name="sql">
+      <![CDATA[select floor(hiredate to day) as d
+from sales.emp_b
+where floor(hiredate to day) < timestamp '2010-02-04 13:00:00']]>
+    </Resource>
+    <Resource name="planBefore">
+      <![CDATA[
+LogicalProject(D=[FLOOR($4, FLAG(DAY))])
+  LogicalFilter(condition=[<(FLOOR($4, FLAG(DAY)), 2010-02-04 13:00:00)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
+]]>
+    </Resource>
+    <Resource name="planAfter">
+      <![CDATA[
+LogicalProject(D=[FLOOR($4, FLAG(DAY))])
+  LogicalFilter(condition=[<($4, 2010-02-05 00:00:00)])
+    LogicalTableScan(table=[[CATALOG, SALES, EMP_B]])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
## Jira Link

[CALCITE-7762](https://issues.apache.org/jira/browse/CALCITE-7762)

## Changes Proposed

`DateRangeRules` has three related problems with sub-day predicates:

```sql
SELECT FLOOR(hiredate TO DAY)
FROM sales.emp_b
WHERE FLOOR(hiredate TO DAY) < TIMESTAMP '2010-02-04 13:00:00';
```

can produce an incorrect range boundary, while

```sql
SELECT EXTRACT(HOUR FROM hiredate)
FROM sales.emp_b
WHERE EXTRACT(YEAR FROM hiredate) = 2010
  AND EXTRACT(HOUR FROM hiredate) = 13;
```

can hang during the rewrite. Lower units can also cause excessive expansion;
for example, rewriting `EXTRACT(SECOND) = 15` over one year would attempt to
enumerate 525,600 ranges.

This change:

* uses `Calendar.HOUR_OF_DAY` and validates `HOUR` in the range 0 through 23;
* adds a configurable range-expansion limit, defaulting to 100 ranges;
* retains the original lower-unit predicate when rewriting it would exceed the
  limit;
* applies the same limit when expanding `SEARCH` predicates; and
* allows callers to select unlimited expansion explicitly with `-1`.

The tests cover the corrected `FLOOR` and `CEIL` relational plans, 24-hour
`EXTRACT(HOUR)` behavior, bounded `HOUR` and `SECOND` rewrites, exact-limit and
over-limit behavior, and `SEARCH` expansion.

Validation: `./gradlew build` (16,734 tests completed, 0 failed).
