### PR TITLE
[CALCITE-4596] RelFieldTrimmer#trimFields fails if values row type is empty record

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql2rel/RelFieldTrimmer.java
+++ b/core/src/main/java/org/apache/calcite/sql2rel/RelFieldTrimmer.java
@@ -1030,8 +1030,13 @@ public class RelFieldTrimmer implements ReflectiveVisitor {
 
     // Fennel abhors an empty row type, so pretend that the parent rel
     // wants the last field. (The last field is the least likely to be a
-    // system field.)
+    // system field.) But if the input already has zero columns, there is
+    // no field to give; return it unchanged.
     if (fieldsUsed.isEmpty()) {
+      if (fieldCount == 0) {
+        Mapping mapping = Mappings.createIdentity(fieldCount);
+        return result(setOp, mapping);
+      }
       fieldsUsed = ImmutableBitSet.of(rowType.getFieldCount() - 1);
     }
 
@@ -1301,8 +1306,13 @@ public class RelFieldTrimmer implements ReflectiveVisitor {
 
     // If they are asking for no fields, we can't give them what they want,
     // because zero-column records are illegal. Give them the last field,
-    // which is unlikely to be a system field.
+    // which is unlikely to be a system field. But if the input already has
+    // zero columns, there is no field to give; return it unchanged.
     if (fieldsUsed.isEmpty()) {
+      if (fieldCount == 0) {
+        Mapping mapping = Mappings.createIdentity(fieldCount);
+        return result(values, mapping);
+      }
       fieldsUsed = ImmutableBitSet.range(fieldCount - 1, fieldCount);
     }
 

--- a/core/src/test/java/org/apache/calcite/sql2rel/RelFieldTrimmerTest.java
+++ b/core/src/test/java/org/apache/calcite/sql2rel/RelFieldTrimmerTest.java
@@ -31,7 +31,9 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.hint.HintPredicates;
 import org.apache.calcite.rel.hint.HintStrategyTable;
 import org.apache.calcite.rel.hint.RelHint;
+import org.apache.calcite.rel.logical.LogicalValues;
 import org.apache.calcite.rel.rules.CoreRules;
+import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCorrelVariable;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.schema.SchemaPlus;
@@ -551,6 +553,23 @@ class RelFieldTrimmerTest {
           + "  LogicalValues(tuples=[[{ 0 }, { 2 }]])\n";
       assertThat(trimmed, hasTree(expected));
     }
+  }
+
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-4596">[CALCITE-4596]
+   * RelFieldTrimmer#trimFields fails if values row type is empty record</a>. */
+  @Test void testTrimEmptyValues() {
+    final RelBuilder builder = RelBuilder.create(config().build());
+    final RelDataType rowType = builder.getTypeFactory().builder().build();
+    final RelNode root = builder.values(rowType).build();
+
+    final RelFieldTrimmer fieldTrimmer = new RelFieldTrimmer(null, builder);
+    final RelNode trimmed = fieldTrimmer.trim(root);
+
+    final String expected = ""
+        + "LogicalValues(tuples=[[]])\n";
+    assertThat(trimmed, instanceOf(LogicalValues.class));
+    assertThat(trimmed, hasTree(expected));
   }
 
   @Test void testUnionFieldTrimmer() {


### PR DESCRIPTION
jira: https://issues.apache.org/jira/browse/CALCITE-4596