### PR TITLE
[CALCITE-7774] JDBC adapter generates a GROUP BY with a constant key, which SQL Server rejects

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -270,6 +270,10 @@ public class MssqlSqlDialect extends SqlDialect {
     return false;
   }
 
+  @Override public boolean supportsGroupByLiteral() {
+    return false;
+  }
+
   @Override public boolean supportsGroupByWithRollup() {
     return true;
   }

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -590,9 +590,13 @@ class RelToSqlConverterTest {
         + "(SELECT TRUE AS \"$f0\") AS \"t\"\nGROUP BY \"t\".\"$f0\"";
     String expectedInformix = "SELECT AVG(employee.salary)\nFROM foodmart.employee,"
         + "\n(SELECT TRUE AS $f0) AS t\nGROUP BY t.$f0";
+    String expectedMssql = "SELECT AVG([employee].[salary])\n"
+        + "FROM [foodmart].[employee],\n"
+        + "(VALUES (1)) AS [t] ([$f0])\nGROUP BY [t].[$f0]";
     sql(query)
         .withRedshift().ok(expectedRedshift)
-        .withInformix().ok(expectedInformix);
+        .withInformix().ok(expectedInformix)
+        .withMssql().ok(expectedMssql);
   }
 
   /** Test case for
@@ -669,9 +673,13 @@ class RelToSqlConverterTest {
         + "(SELECT DATE '2022-01-01' AS \"$f0\") AS \"t\"\nGROUP BY \"t\".\"$f0\"";
     String expectedInformix = "SELECT AVG(employee.salary)\nFROM foodmart.employee,"
         + "\n(SELECT DATE '2022-01-01' AS $f0) AS t\nGROUP BY t.$f0";
+    String expectedMssql = "SELECT AVG([employee].[salary])\n"
+        + "FROM [foodmart].[employee],\n"
+        + "(VALUES ('2022-01-01')) AS [t] ([$f0])\nGROUP BY [t].[$f0]";
     sql(query)
         .withRedshift().ok(expectedRedshift)
-        .withInformix().ok(expectedInformix);
+        .withInformix().ok(expectedInformix)
+        .withMssql().ok(expectedMssql);
   }
 
   @Test void testSimpleSelectStarFromProductTable() {


### PR DESCRIPTION
## Jira Link

[CALCITE-7774](https://issues.apache.org/jira/browse/CALCITE-7774)

## Changes Proposed

`MssqlSqlDialect` now returns false from `supportsGroupByLiteral()`, so `SqlImplementor.visitRoot` applies `AggregateProjectConstantToDummyJoinRule` and the constant moves out of the `GROUP BY` into a dummy join. SQL Server has no form of `GROUP BY <constant>` it will accept, so there was nothing to fix in the unparsing.

Added MSSQL expectations to `testGroupByBooleanLiteral` and `testGroupByDateLiteral`, which already cover Redshift and Informix for the same gate.
