### PR TITLE
[CALCITE-7777] JDBC adapter generates || for concatenation, which SQL Server rejects

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -212,6 +212,11 @@ public class MssqlSqlDialect extends SqlDialect {
       final SqlWriter.Frame frame = writer.startFunCall("CEILING");
       call.operand(0).unparse(writer, leftPrec, rightPrec);
       writer.endFunCall(frame);
+    } else if (call.getOperator().equals(SqlStdOperatorTable.CONCAT)) {
+      // MSSQL has no || operator. + concatenates and propagates NULL, as ||
+      // does; the CONCAT function does not, reading a NULL operand as ''.
+      SqlSyntax.BINARY.unparse(writer, SqlStdOperatorTable.PLUS, call, leftPrec,
+          rightPrec);
     } else {
       switch (call.getKind()) {
       case FLOOR:

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -11820,6 +11820,15 @@ class RelToSqlConverterTest {
     sql(query).dialect(MssqlSqlDialect.DEFAULT).ok(mssqlExpected);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7777">[CALCITE-7777]
+   * JDBC adapter generates || for concatenation, which SQL Server rejects</a>. */
+  @Test void testConcatOperatorEmulationForMSSQL() {
+    final String query = "select \"brand_name\" || \"product_name\" from \"product\"";
+    final String mssqlExpected = "SELECT [brand_name] + [product_name]\n"
+        + "FROM [foodmart].[product]";
+    sql(query).withMssql().ok(mssqlExpected);
+  }
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6655">[CALCITE-6655]


### PR DESCRIPTION
## Jira Link

[CALCITE-7777](https://issues.apache.org/jira/browse/CALCITE-7777)

## Changes Proposed

`MssqlSqlDialect` writes the `||` operator as `+`. SQL Server has no `||`, and `+` is the only rendering that keeps what `||` means: it propagates NULL, where the `CONCAT` function reads a NULL operand as the empty string and would turn a NULL result into a row.
