### PR TITLE
[CALCITE-7778] JDBC adapter for MSSQL generates % for MOD without preserving grouping, giving wrong results

### DIFF
--- a/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
+++ b/core/src/main/java/org/apache/calcite/sql/dialect/MssqlSqlDialect.java
@@ -35,8 +35,6 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
-import org.apache.calcite.sql.SqlOperator;
-import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlLibraryOperators;
@@ -49,6 +47,7 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import static org.apache.calcite.util.RelToSqlConverterUtil.unparseBoolLiteralToCondition;
+import static org.apache.calcite.util.RelToSqlConverterUtil.unparseWithOperator;
 
 import static java.util.Objects.requireNonNull;
 
@@ -222,8 +221,8 @@ public class MssqlSqlDialect extends SqlDialect {
         unparseFloor(writer, call);
         break;
       case MOD:
-        SqlOperator op = SqlStdOperatorTable.PERCENT_REMAINDER;
-        SqlSyntax.BINARY.unparse(writer, op, call, leftPrec, rightPrec);
+        unparseWithOperator(writer, SqlStdOperatorTable.PERCENT_REMAINDER, call,
+            leftPrec, rightPrec);
         break;
       case SAFE_CAST:
         // MSSQL uses TRY_CAST instead of SAFE_CAST (BigQuery)

--- a/core/src/main/java/org/apache/calcite/util/RelToSqlConverterUtil.java
+++ b/core/src/main/java/org/apache/calcite/util/RelToSqlConverterUtil.java
@@ -346,17 +346,8 @@ public abstract class RelToSqlConverterUtil {
    * parenthesized as that operator requires.
    *
    * <p>{@link SqlCall#unparse} chooses the parentheses from the call's own
-   * operator, before the dialect is consulted. Writing the call with an
-   * operator that binds less tightly therefore drops parentheses that were
-   * holding the grouping, and the target system regroups the expression. Where
-   * the call arrived already parenthesized both precedences are zero and
-   * nothing further is written.
-   *
-   * @param writer current SqlWriter object
-   * @param operator operator to write the call with
-   * @param call call to write
-   * @param leftPrec left precedence the call was given
-   * @param rightPrec right precedence the call was given
+   * operator before the dialect is consulted, so an operator that binds less
+   * tightly needs them added here.
    */
   public static void unparseWithOperator(SqlWriter writer, SqlOperator operator,
       SqlCall call, int leftPrec, int rightPrec) {

--- a/core/src/main/java/org/apache/calcite/util/RelToSqlConverterUtil.java
+++ b/core/src/main/java/org/apache/calcite/util/RelToSqlConverterUtil.java
@@ -31,7 +31,9 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlMapTypeNameSpec;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlSyntax;
 import org.apache.calcite.sql.SqlTypeNameSpec;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -337,6 +339,35 @@ public abstract class RelToSqlConverterUtil {
     writer.sep(SqlStdOperatorTable.EQUALS.getName());
     writer.literal(value ? "1" : "0");
     writer.endList(frame);
+  }
+
+  /**
+   * Writes a two-operand call with an operator other than its own,
+   * parenthesized as that operator requires.
+   *
+   * <p>{@link SqlCall#unparse} chooses the parentheses from the call's own
+   * operator, before the dialect is consulted. Writing the call with an
+   * operator that binds less tightly therefore drops parentheses that were
+   * holding the grouping, and the target system regroups the expression. Where
+   * the call arrived already parenthesized both precedences are zero and
+   * nothing further is written.
+   *
+   * @param writer current SqlWriter object
+   * @param operator operator to write the call with
+   * @param call call to write
+   * @param leftPrec left precedence the call was given
+   * @param rightPrec right precedence the call was given
+   */
+  public static void unparseWithOperator(SqlWriter writer, SqlOperator operator,
+      SqlCall call, int leftPrec, int rightPrec) {
+    if (leftPrec > operator.getLeftPrec()
+        || (operator.getRightPrec() <= rightPrec && rightPrec != 0)) {
+      final SqlWriter.Frame frame = writer.startList("(", ")");
+      SqlSyntax.BINARY.unparse(writer, operator, call, 0, 0);
+      writer.endList(frame);
+    } else {
+      SqlSyntax.BINARY.unparse(writer, operator, call, leftPrec, rightPrec);
+    }
   }
 
   /**

--- a/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
+++ b/core/src/test/java/org/apache/calcite/rel/rel2sql/RelToSqlConverterTest.java
@@ -11820,6 +11820,22 @@ class RelToSqlConverterTest {
     sql(query).dialect(MssqlSqlDialect.DEFAULT).ok(mssqlExpected);
   }
 
+  /** Test case for
+   * <a href="https://issues.apache.org/jira/browse/CALCITE-7778">[CALCITE-7778]
+   * JDBC adapter for MSSQL generates % for MOD without preserving grouping,
+   * giving wrong results</a>. */
+  @Test void testModFunctionGroupingForMSSQL() {
+    final String from = "\nFROM (VALUES (0)) AS [t] ([ZERO])";
+    sql("select 100 / mod(11, 3)").dialect(MssqlSqlDialect.DEFAULT)
+        .ok("SELECT 100 / (11 % 3)" + from);
+    sql("select 100 * mod(11, 3)").dialect(MssqlSqlDialect.DEFAULT)
+        .ok("SELECT 100 * (11 % 3)" + from);
+    sql("select mod(100, mod(11, 3))").dialect(MssqlSqlDialect.DEFAULT)
+        .ok("SELECT 100 % (11 % 3)" + from);
+    // % already binds more tightly than -, so no parentheses are needed
+    sql("select 100 - mod(11, 3)").dialect(MssqlSqlDialect.DEFAULT)
+        .ok("SELECT 100 - 11 % 3" + from);
+  }
 
   /** Test case for
    * <a href="https://issues.apache.org/jira/browse/CALCITE-6655">[CALCITE-6655]


### PR DESCRIPTION
## Jira Link

[CALCITE-7778](https://issues.apache.org/jira/browse/CALCITE-7778)

## Changes Proposed

Parenthesize the `%` written for `MOD` where its lower precedence requires it. Shared in `RelToSqlConverterUtil` rather than the dialect, since `HiveSqlDialect` makes the same substitution and somebody might want to fix that also some day.
